### PR TITLE
[CHORE] color extension

### DIFF
--- a/Sofa/Configuration/Extensions/Color.swift
+++ b/Sofa/Configuration/Extensions/Color.swift
@@ -9,18 +9,16 @@ import Foundation
 import SwiftUI
 
 extension Color {
-    init(hexcode: String) {
-        let scanner = Scanner(string: hexcode)
-        var rgbValue: UInt64 = 0
-        
-        scanner.scanHexInt64(&rgbValue)
-        
-        let red = (rgbValue & 0xff0000) >> 16
-        let green = (rgbValue & 0xff00) >> 8
-        let blue = rgbValue & 0xff
-        
-        self.init(red: Double(red) / 0xff, green: Double(green) / 0xff, blue: Double(blue) / 0xff)
-        
-    }
+  init(hex: String) {
+    let scanner = Scanner(string: hex)
+    _ = scanner.scanString("#")
+    
+    var rgb: UInt64 = 0
+    scanner.scanHexInt64(&rgb)
+    
+    let r = Double((rgb >> 16) & 0xFF) / 255.0
+    let g = Double((rgb >>  8) & 0xFF) / 255.0
+    let b = Double((rgb >>  0) & 0xFF) / 255.0
+    self.init(red: r, green: g, blue: b)
+  }
 }
-


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Color extension 수정

🌱 PR 포인트
- 기존에는 hex 값에 #도 붙여야했다면 이제 안붙여도 작동합니다. `Color(hexcode: "#29662C")`  `Color(hexcode: "29662C")`

## 📸 스크린샷
|Figma|사용 방법|
|---|---|
|![스크린샷 2022-06-12 오후 3 22 20](https://user-images.githubusercontent.com/70887135/173219974-2ed80d71-4324-4b3e-9761-8203dadee7d2.png)|![스크린샷 2022-06-14 오전 12 22 34](https://user-images.githubusercontent.com/70887135/173388163-dcc27f18-65ee-47ab-97eb-a151ec8851fb.png)|



## 📮 관련 이슈
- Resolved: #23 
