### PR TITLE
[FEAT] 앨범 Detail View action sheet 와 디자인 수정

### DIFF
--- a/Sofa/Configuration/ViewModifiers/NavigationBarWithIconButtonStyle.swift
+++ b/Sofa/Configuration/ViewModifiers/NavigationBarWithIconButtonStyle.swift
@@ -20,7 +20,7 @@ struct NavigationBarWithIconButtonStyle: ViewModifier {
           .font(.system(size: 24, weight: .bold))
           .padding(EdgeInsets(top: 8, leading: 8 * 24 / 30.5, bottom: 8, trailing: 8)), // trailing Item 기준 비율로 맞춰줌
         trailing: Button(action: {
-          UITabBar.toogleTabBarVisibility()
+          UITabBar.hideTabBar(animated: false)
           isButtonClick = true
         }, label: {
           Image(systemName: buttonName)

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -40,6 +40,9 @@ struct AlbumDetailView: View {
       outOfFocusOpacity: 0.2,
       itemsSpacing: 0
     )
+    .onDisappear {
+      UITabBar.hideTabBar()
+    }
   }
   
   var body: some View {

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -8,16 +8,28 @@
 import SwiftUI
 
 struct AlbumDetailView: View {
-  @State var isNext = false
   @State var isEdit = false
+  
+  // 이미지
+  @State var isImageClick: Bool = false
+  @State var selectImage: UIImage = UIImage()
+  @State var selectImageIndex: Int = -1
+
+  @State var isBookmarkClick: Bool = false
+  @State var isCommentClick: Bool = false
+  @State var isEllipsisClick: Bool = false
   let info = MockData().albumDetail
   
   var body: some View {
     NavigationView {
       VStack {
-        AlbumDetailList(isNext: $isNext)
+        AlbumDetailList(isImageClick: $isImageClick, selectImage: $selectImage, selectImageIndex: $selectImageIndex, isBookmarkClick: $isBookmarkClick, isCommentClick: $isCommentClick, isEllipsisClick: $isEllipsisClick)
         
-        NavigationLink("", destination: EmptyView(), isActive: $isNext)
+        // 이미지 click
+        NavigationLink("", destination: EmptyView(), isActive: $isImageClick)
+        
+        // 댓글 click
+        NavigationLink("", destination: EmptyView(), isActive: $isCommentClick)
       }
       .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
       .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -40,8 +40,8 @@ struct AlbumDetailView: View {
     }
     .navigationViewStyle(StackNavigationViewStyle())
     .navigationBarHidden(true)
-    .onAppear { UITabBar.toogleTabBarVisibility() }
-    .onDisappear { UITabBar.toogleTabBarVisibility() }
+    .onAppear { UITabBar.hideTabBar() }
+    .onDisappear { UITabBar.showTabBar() }
   }
 }
 

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -40,9 +40,6 @@ struct AlbumDetailView: View {
       outOfFocusOpacity: 0.2,
       itemsSpacing: 0
     )
-    .onDisappear {
-      UITabBar.hideTabBar()
-    }
   }
   
   var body: some View {

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -14,34 +14,58 @@ struct AlbumDetailView: View {
   @State var isImageClick: Bool = false
   @State var selectImage: UIImage = UIImage()
   @State var selectImageIndex: Int = -1
-
+  
   // 즐겨찾기
   @State var isBookmarkClick: Bool = false
   @State private var messageData: ToastMessage.MessageData = ToastMessage.MessageData(title: "즐겨찾기 등록", type: .Registration)
-
+  
   @State var isCommentClick: Bool = false
   @State var isEllipsisClick: Bool = false
   let info = MockData().albumDetail
   
+  var actionSheetView: some View {
+    ActionSheetCard(
+      isShowing: $isEllipsisClick,
+      items: [
+        ActionSheetCardItem(systemIconName: "arrow.down", label: "다운로드") {
+          isEllipsisClick = false
+        },
+        ActionSheetCardItem(systemIconName: "calnder", label: "날짜 수정") {
+          isEllipsisClick = false
+        },
+        ActionSheetCardItem(systemIconName: "trash", label: "삭제") {
+          isEllipsisClick = false
+        }
+      ],
+      outOfFocusOpacity: 0.2,
+      itemsSpacing: 0
+    )
+  }
+  
   var body: some View {
-    NavigationView {
-      VStack {
-        AlbumDetailList(isImageClick: $isImageClick, selectImage: $selectImage, selectImageIndex: $selectImageIndex, isBookmarkClick: $isBookmarkClick, isCommentClick: $isCommentClick, isEllipsisClick: $isEllipsisClick)
-        
-        // 이미지 click
-        NavigationLink("", destination: EmptyView(), isActive: $isImageClick)
-        
-        // 댓글 click
-        NavigationLink("", destination: EmptyView(), isActive: $isCommentClick)
+    ZStack {
+      NavigationView {
+        VStack {
+          AlbumDetailList(isImageClick: $isImageClick, selectImage: $selectImage, selectImageIndex: $selectImageIndex, isBookmarkClick: $isBookmarkClick, isCommentClick: $isCommentClick, isEllipsisClick: $isEllipsisClick)
+          
+          // 이미지 click
+          NavigationLink("", destination: EmptyView(), isActive: $isImageClick)
+          
+          // 댓글 click
+          NavigationLink("", destination: EmptyView(), isActive: $isCommentClick)
+          
+        }
+        .toastMessage(data: $messageData, isShow: $isBookmarkClick)
+        .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
+        .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
       }
-      .toastMessage(data: $messageData, isShow: $isBookmarkClick)
-      .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
-      .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
+      .navigationViewStyle(StackNavigationViewStyle())
+      .navigationBarHidden(true)
+      .onAppear { UITabBar.hideTabBar() }
+      .onDisappear { UITabBar.showTabBar() }
+      
+      actionSheetView // 바텀 Sheet
     }
-    .navigationViewStyle(StackNavigationViewStyle())
-    .navigationBarHidden(true)
-    .onAppear { UITabBar.hideTabBar() }
-    .onDisappear { UITabBar.showTabBar() }
   }
 }
 

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -15,7 +15,10 @@ struct AlbumDetailView: View {
   @State var selectImage: UIImage = UIImage()
   @State var selectImageIndex: Int = -1
 
+  // 즐겨찾기
   @State var isBookmarkClick: Bool = false
+  @State private var messageData: ToastMessage.MessageData = ToastMessage.MessageData(title: "즐겨찾기 등록", type: .Registration)
+
   @State var isCommentClick: Bool = false
   @State var isEllipsisClick: Bool = false
   let info = MockData().albumDetail
@@ -32,6 +35,7 @@ struct AlbumDetailView: View {
         NavigationLink("", destination: EmptyView(), isActive: $isCommentClick)
       }
       .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
+      .toastMessage(data: $messageData, isShow: $isBookmarkClick)
       .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
     }
     .navigationViewStyle(StackNavigationViewStyle())

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -34,8 +34,8 @@ struct AlbumDetailView: View {
         // 댓글 click
         NavigationLink("", destination: EmptyView(), isActive: $isCommentClick)
       }
-      .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
       .toastMessage(data: $messageData, isShow: $isBookmarkClick)
+      .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
       .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
     }
     .navigationViewStyle(StackNavigationViewStyle())

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -30,10 +30,10 @@ struct AlbumDetailView: View {
         ActionSheetCardItem(systemIconName: "arrow.down", label: "다운로드") {
           isEllipsisClick = false
         },
-        ActionSheetCardItem(systemIconName: "calnder", label: "날짜 수정") {
+        ActionSheetCardItem(systemIconName: "calendar", label: "날짜 수정") {
           isEllipsisClick = false
         },
-        ActionSheetCardItem(systemIconName: "trash", label: "삭제") {
+        ActionSheetCardItem(systemIconName: "trash", label: "삭제", foregrounColor: Color(hex: "#EC407A")) {
           isEllipsisClick = false
         }
       ],

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailList.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailList.swift
@@ -15,8 +15,8 @@ struct AlbumDetailList: View {
     ScrollView {
       // 필요할때 rendering 함, network에 적합
       LazyVStack(spacing: 10) {
-        ForEach(viewModel.posts) { element in
-          AlbumDetailRow(isNext: $isNext, info: element)
+        ForEach(Array(zip(viewModel.posts.indices, viewModel.posts)), id: \.0) { index, element in
+          AlbumDetailRow(isNext: $isNext, info: element, index: index)
             .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
         }
       }

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailList.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailList.swift
@@ -9,14 +9,23 @@ import SwiftUI
 
 struct AlbumDetailList: View {
   @ObservedObject var viewModel = AlbumDetailViewModel()
-  @Binding var isNext: Bool
+  
+  // 이미지
+  @Binding var isImageClick: Bool
+  @Binding var selectImage: UIImage
+  @Binding var selectImageIndex: Int
+
+  @Binding var isBookmarkClick: Bool
+  @Binding var isCommentClick: Bool
+  @Binding var isEllipsisClick: Bool
   
   var body: some View {
     ScrollView {
       // 필요할때 rendering 함, network에 적합
       LazyVStack(spacing: 10) {
         ForEach(Array(zip(viewModel.posts.indices, viewModel.posts)), id: \.0) { index, element in
-          AlbumDetailRow(isNext: $isNext, info: element, index: index)
+          AlbumDetailRow(isImageClick: $isImageClick, selectImage: $selectImage, selectImageIndex: $selectImageIndex, isBookmarkClick: $isBookmarkClick, isCommentClick: $isCommentClick, isEllipsisClick: $isEllipsisClick, info: element, index: index)
+
             .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
         }
       }
@@ -26,7 +35,9 @@ struct AlbumDetailList: View {
 
 struct AlbumDetailList_Previews: PreviewProvider {
   static var previews: some View {
-    AlbumDetailList(isNext: .constant(false))
+    let data = MockData().albumDetail.elements[0]
+    
+    AlbumDetailList(isImageClick: .constant(false), selectImage: .constant(UIImage(named: data.link)!), selectImageIndex: .constant(0), isBookmarkClick: .constant(false), isCommentClick: .constant(false), isEllipsisClick: .constant(false))
   }
 }
 

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -10,12 +10,14 @@ import SwiftUI
 struct AlbumDetailRow: View {
   @Binding var isNext: Bool
   let info: AlbumDetailElement // 임시 @ObservedObject로 변경해야함
+  let index: Int
   private var isBookmark : Bool { return info.favourite }
   
   var body: some View {
     VStack(spacing: 10) {
       Button(action: {
         isNext = true
+        print(index)
       }, label: {
         // post image
         Image(info.link)
@@ -75,7 +77,6 @@ struct AlbumDetailRow: View {
             .font(.system(size: 20))
             .padding(.trailing, 4.5)
         }
-        
       }
     }
   }
@@ -85,6 +86,6 @@ struct AlbumDetailRow_Previews: PreviewProvider {
   static var previews: some View {
     let data = MockData().albumDetail.elements[3]
     
-    AlbumDetailRow(isNext: .constant(false), info: data)
+    AlbumDetailRow(isNext: .constant(false), info: data, index: 3)
   }
 }

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -13,7 +13,7 @@ struct AlbumDetailRow: View {
   private var isBookmark : Bool { return info.favourite }
   
   var body: some View {
-    VStack(spacing: info.type != "PHOTO" ? 10 : 4) {
+    VStack(spacing: 10) {
       Button(action: {
         isNext = true
       }, label: {
@@ -29,31 +29,13 @@ struct AlbumDetailRow: View {
           Text(info.title!)
             .foregroundColor(Color(UIColor.label))
             .font(.system(size: 18, weight: .semibold))
+            .padding(.top, -6) // top : 4
           
           Spacer()
         }
       }
       
       HStack {
-        HStack(spacing: 3) {
-          Image(systemName: "ellipsis.bubble")
-            .frame(width: 20, height: 20)
-            .foregroundColor(.gray)
-            .font(.system(size: 20))
-            .padding(4)
-          
-          // 댓글 수
-          Text("\(info.commentCount)")
-            .foregroundColor(.gray)
-            .font(.system(size: 20))
-        }
-        .padding(EdgeInsets(top: 0, leading: 49, bottom: 0, trailing: 0))
-        
-        Spacer()
-      }
-    }
-    .overlay (
-      HStack(spacing: 16) {
         Button(action: {
           print("bookmark click")
         }) {
@@ -62,21 +44,40 @@ struct AlbumDetailRow: View {
             .frame(width: 20, height: 20)
             .foregroundColor(isBookmark ? Color(hex: "#FFCA28") : .gray)
             .font(.system(size: 20))
-            .padding(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 0))
+            .padding(.leading, 8)
         }
+        
+        Button(action: {
+          
+        }, label: {
+          HStack(spacing: 8) {
+            Image(systemName: "ellipsis.bubble")
+              .frame(width: 20, height: 20)
+              .foregroundColor(.gray)
+              .font(.system(size: 20))
+              .padding(.leading, 20)
+            
+            // 댓글 수
+            Text("\(info.commentCount)")
+              .foregroundColor(.gray)
+              .font(.system(size: 20))
+          }
+        })
         
         Spacer()
         
         Button(action: {
+          
         }) {
           Image(systemName: "ellipsis")
             .frame(width: 20, height: 20)
             .foregroundColor(.gray)
             .font(.system(size: 20))
-            .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 5))
+            .padding(.trailing, 4.5)
         }
-      }.offset(y: info.type == "PHOTO" ? 140 : 158) // image위에 icon button 올려놓기
-    )
+        
+      }
+    }
   }
 }
 

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -13,46 +13,45 @@ struct AlbumDetailRow: View {
   private var isBookmark : Bool { return info.favourite }
   
   var body: some View {
-    Button(action: {
-      isNext = true
-    }, label: {
-      VStack(spacing: info.type != "PHOTO" ? 10 : 4) {
+    VStack(spacing: info.type != "PHOTO" ? 10 : 4) {
+      Button(action: {
+        isNext = true
+      }, label: {
         // post image
         Image(info.link)
           .resizable()
           .frame(height: Screen.maxWidth * 0.7)
           .cornerRadius(8)
-        
-        
-        if info.type != "PHOTO" { // RECORDING
-          HStack {
-            Text(info.title!)
-              .foregroundColor(Color(UIColor.label))
-              .font(.system(size: 18, weight: .semibold))
-            
-            Spacer()
-          }
-        }
-        
+      })
+      
+      if info.type != "PHOTO" { // RECORDING
         HStack {
-          HStack(spacing: 3) {
-            Image(systemName: "ellipsis.bubble")
-              .frame(width: 20, height: 20)
-              .foregroundColor(.gray)
-              .font(.system(size: 20))
-              .padding(4)
-            
-            // 댓글 수
-            Text("\(info.commentCount)")
-              .foregroundColor(.gray)
-              .font(.system(size: 20))
-          }
-          .padding(EdgeInsets(top: 0, leading: 49, bottom: 0, trailing: 0))
+          Text(info.title!)
+            .foregroundColor(Color(UIColor.label))
+            .font(.system(size: 18, weight: .semibold))
           
           Spacer()
         }
       }
-    })
+      
+      HStack {
+        HStack(spacing: 3) {
+          Image(systemName: "ellipsis.bubble")
+            .frame(width: 20, height: 20)
+            .foregroundColor(.gray)
+            .font(.system(size: 20))
+            .padding(4)
+          
+          // 댓글 수
+          Text("\(info.commentCount)")
+            .foregroundColor(.gray)
+            .font(.system(size: 20))
+        }
+        .padding(EdgeInsets(top: 0, leading: 49, bottom: 0, trailing: 0))
+        
+        Spacer()
+      }
+    }
     .overlay (
       HStack(spacing: 16) {
         Button(action: {

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -8,7 +8,15 @@
 import SwiftUI
 
 struct AlbumDetailRow: View {
-  @Binding var isNext: Bool
+  // 이미지
+  @Binding var isImageClick: Bool
+  @Binding var selectImage: UIImage
+  @Binding var selectImageIndex: Int
+
+  @Binding var isBookmarkClick: Bool
+  @Binding var isCommentClick: Bool
+  @Binding var isEllipsisClick: Bool
+
   let info: AlbumDetailElement // 임시 @ObservedObject로 변경해야함
   let index: Int
   private var isBookmark : Bool { return info.favourite }
@@ -16,8 +24,9 @@ struct AlbumDetailRow: View {
   var body: some View {
     VStack(spacing: 10) {
       Button(action: {
-        isNext = true
-        print(index)
+        isImageClick = true
+        selectImage = UIImage(named: info.link)!
+        selectImageIndex = index
       }, label: {
         // post image
         Image(info.link)
@@ -39,7 +48,8 @@ struct AlbumDetailRow: View {
       
       HStack {
         Button(action: {
-          print("bookmark click")
+          isBookmarkClick = true
+          selectImageIndex = index
         }) {
           // 북마크
           Image(systemName: isBookmark ? "bookmark.fill" : "bookmark")
@@ -50,7 +60,8 @@ struct AlbumDetailRow: View {
         }
         
         Button(action: {
-          
+          isCommentClick = true
+          selectImageIndex = index
         }, label: {
           HStack(spacing: 8) {
             Image(systemName: "ellipsis.bubble")
@@ -69,7 +80,8 @@ struct AlbumDetailRow: View {
         Spacer()
         
         Button(action: {
-          
+          isEllipsisClick = true
+          selectImageIndex = index
         }) {
           Image(systemName: "ellipsis")
             .frame(width: 20, height: 20)
@@ -86,6 +98,6 @@ struct AlbumDetailRow_Previews: PreviewProvider {
   static var previews: some View {
     let data = MockData().albumDetail.elements[3]
     
-    AlbumDetailRow(isNext: .constant(false), info: data, index: 3)
+    AlbumDetailRow(isImageClick: .constant(false), selectImage: .constant(UIImage(named: data.link)!), selectImageIndex: .constant(0), isBookmarkClick: .constant(false), isCommentClick: .constant(false), isEllipsisClick: .constant(false), info: data, index: 3)
   }
 }

--- a/Sofa/Sources/View/Album/AlbumPhotoAddView/AlbumPhotoAddView.swift
+++ b/Sofa/Sources/View/Album/AlbumPhotoAddView/AlbumPhotoAddView.swift
@@ -43,8 +43,8 @@ struct AlbumPhotoAddView: View {
       }
       .background(Color.black) // 배경색
       .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
-      .navigationBarInlineStyle(isNextClick: $isNext, isDisalbeNextButton: .constant(selected.isEmpty), buttonColor: Color.init(hex: "#43A047"), "사진 선택") // 임시 컬러
       .toastMessage(data: $messageData, isShow: $showToastMessage)
+      .navigationBarInlineStyle(isNextClick: $isNext, isDisalbeNextButton: .constant(selected.isEmpty), buttonColor: Color.init(hex: "#43A047"), "사진 선택") // 임시 컬러
     }
   }
 }

--- a/Sofa/Sources/View/Album/AlbumView.swift
+++ b/Sofa/Sources/View/Album/AlbumView.swift
@@ -21,17 +21,14 @@ struct AlbumView: View {
       isShowing: $showingSheet,
       items: [
         ActionSheetCardItem(systemIconName: "photo", label: "사진") {
-          UITabBar.showTabBar()
           showingSheet = false
           authorizationViewModel.showPhotoAlbum() // 권한 확인
         },
         ActionSheetCardItem(systemIconName: "camera", label: "카메라") {
-          UITabBar.showTabBar()
           showingSheet = false
           authorizationViewModel.showCameraPicker() // 권한 확인
         },
         ActionSheetCardItem(systemIconName: "waveform", label: "녹음") {
-          UITabBar.showTabBar()
           showingSheet = false
           authorizationViewModel.showAudioRecord() // 권한 확인
         }
@@ -39,6 +36,9 @@ struct AlbumView: View {
       outOfFocusOpacity: 0.2,
       itemsSpacing: 0
     )
+    .onDisappear {
+      UITabBar.showTabBar()
+    }
   }
   
   var body: some View {

--- a/Sofa/Sources/View/Album/AlbumView.swift
+++ b/Sofa/Sources/View/Album/AlbumView.swift
@@ -21,17 +21,17 @@ struct AlbumView: View {
       isShowing: $showingSheet,
       items: [
         ActionSheetCardItem(systemIconName: "photo", label: "사진") {
-          UITabBar.toogleTabBarVisibility()
+          UITabBar.showTabBar()
           showingSheet = false
           authorizationViewModel.showPhotoAlbum() // 권한 확인
         },
         ActionSheetCardItem(systemIconName: "camera", label: "카메라") {
-          UITabBar.toogleTabBarVisibility()
+          UITabBar.showTabBar()
           showingSheet = false
           authorizationViewModel.showCameraPicker() // 권한 확인
         },
         ActionSheetCardItem(systemIconName: "waveform", label: "녹음") {
-          UITabBar.toogleTabBarVisibility()
+          UITabBar.showTabBar()
           showingSheet = false
           authorizationViewModel.showAudioRecord() // 권한 확인
         }

--- a/Sofa/Sources/View/Album/SubViews/ActionSheet/AlbumActionSheetCard.swift
+++ b/Sofa/Sources/View/Album/SubViews/ActionSheet/AlbumActionSheetCard.swift
@@ -43,7 +43,7 @@ public struct ActionSheetCard: View {
     offset = heightToDisappear
     isDragging = false
     isShowing = false
-    UITabBar.toogleTabBarVisibility()
+    UITabBar.hideTabBar()
   }
   
   var topHalfMiddleBar: some View {

--- a/Sofa/Sources/View/Album/SubViews/ActionSheet/AlbumActionSheetCard.swift
+++ b/Sofa/Sources/View/Album/SubViews/ActionSheet/AlbumActionSheetCard.swift
@@ -43,7 +43,6 @@ public struct ActionSheetCard: View {
     offset = heightToDisappear
     isDragging = false
     isShowing = false
-    UITabBar.hideTabBar()
   }
   
   var topHalfMiddleBar: some View {
@@ -96,7 +95,6 @@ public struct ActionSheetCard: View {
     Group {
       if isShowing {
         GreyOutOfFocusView(opacity: outOfFocusOpacity) {
-          UITabBar.toogleTabBarVisibility()
           self.isShowing = false
         }
       }

--- a/Sofa/Sources/View/Album/SubViews/ActionSheet/AlbumActionSheetItem.swift
+++ b/Sofa/Sources/View/Album/SubViews/ActionSheet/AlbumActionSheetItem.swift
@@ -27,7 +27,7 @@ public struct ActionSheetCardItem: View {
     iconLeadingPadding: CGFloat? = nil,
     iconTrailingPadding: CGFloat? = nil,
     label: String,
-    labelFont: Font = Font.headline,
+    labelFont: Font = Font.system(size: 16, weight: .semibold),
     foregrounColor: Color = Color.black,
     foregroundInactiveColor: Color = Color.black,
     callback: (() -> ())? = nil
@@ -52,14 +52,14 @@ public struct ActionSheetCardItem: View {
           .aspectRatio(contentMode: .fit)
           .frame(width:iconSize ?? 24, height: iconSize ?? 24)
           .padding(.vertical, iconVerticalPadding)
-          .padding(.leading, iconLeadingPadding ?? 18)
-          .padding(.trailing, iconTrailingPadding ?? 13)
+          .padding(.leading, iconLeadingPadding ?? 32)
+          .padding(.trailing, iconTrailingPadding ?? 10)
       }
     }
   }
   
   var buttonView: some View {
-    HStack (spacing: 0){
+    HStack(spacing: 0) {
       icon
       Text(label)
         .font(labelFont)

--- a/Sofa/Sources/View/Home/SubViews/EventList.swift
+++ b/Sofa/Sources/View/Home/SubViews/EventList.swift
@@ -14,7 +14,7 @@ struct EventList: View {
   var body: some View {
     ScrollView(.horizontal, showsIndicators: false) {
       LazyHStack(spacing: 16) {
-
+        
         ForEach(Array(zip(eventViewModel.events.indices, eventViewModel.events)), id: \.0){ index, event in
           if index == 0{ // 첫번째 row
             EventRow(event)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Album Detail View에 action sheet 추가
- 개별 버튼 event로 변경

🌱 PR 포인트
- Album의 Navigation plus 버튼을 두번 click 하면 tabbar toggle이 꼬이는 문제 해결
- 해결법 : 애니메이션 false - `NavigationBarWithIconButtonStyle`의 `UITabBar.hideTabBar(animated: false)`
- NavigationBarWithIconButtonStyle의 button을 누르면 UITabBar 사라짐
  - 유진님의 홈화면의 알림버튼을 눌렀을 경우, UITabBar 사라짐
  - 알림 View에서 `onDisappear`을 붙여 `UITabBar.showTabBar()`로 해결해야할 것

## 📸 스크린샷
|FEAT|CHORE|
|:--:|:--:|
|![image](https://user-images.githubusercontent.com/48436020/176065532-66695d26-6e44-422c-a662-222e0a4289d5.png) |![image](https://user-images.githubusercontent.com/48436020/175972502-f686c234-c826-42b7-9109-8e625d0be066.png)|
|Album Detail View에 action sheet 추가| 클릭이 안되어야하는 부분 |

## 📮 관련 이슈
- Resolved: #44 
- Resolved: #43 