### PR TITLE
[FEAT] 일정 List Pager 적용

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0A223B70285F74BB002203ED /* Ex+UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A223B6F285F74BB002203ED /* Ex+UIColor.swift */; };
 		0A223B72285F75D6002203ED /* CustomText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A223B71285F75D6002203ED /* CustomText.swift */; };
 		0A2B55092858779D006F816C /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2B55082858779D006F816C /* View.swift */; };
+		0A42E063286DCD0C00A2C73D /* SwiftUIPager in Frameworks */ = {isa = PBXBuildFile; productRef = 0A42E062286DCD0C00A2C73D /* SwiftUIPager */; };
 		0A4CFB8B285F79AB000603A5 /* Ex+Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4CFB8A285F79AB000603A5 /* Ex+Font.swift */; };
 		0A4CFB95285F85C8000603A5 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0A4CFB8C285F85C8000603A5 /* Pretendard-Thin.otf */; };
 		0A4CFB96285F85C8000603A5 /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 0A4CFB8D285F85C8000603A5 /* Pretendard-ExtraBold.otf */; };
@@ -233,6 +234,7 @@
 			files = (
 				0AC79185286B0AE00034A830 /* ConfettiSwiftUI in Frameworks */,
 				187B1EF8C1191F4F7DA3BE39 /* Pods_Sofa.framework in Frameworks */,
+				0A42E063286DCD0C00A2C73D /* SwiftUIPager in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -769,6 +771,7 @@
 			name = Sofa;
 			packageProductDependencies = (
 				0AC79184286B0AE00034A830 /* ConfettiSwiftUI */,
+				0A42E062286DCD0C00A2C73D /* SwiftUIPager */,
 			);
 			productName = Sofa;
 			productReference = C4667A2B284B6FF200A4A759 /* Sofa.app */;
@@ -848,6 +851,7 @@
 			mainGroup = C4667A22284B6FF200A4A759;
 			packageReferences = (
 				0AC79183286B0AE00034A830 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
+				0A42E061286DCD0C00A2C73D /* XCRemoteSwiftPackageReference "SwiftUIPager" */,
 			);
 			productRefGroup = C4667A2C284B6FF200A4A759 /* Products */;
 			projectDirPath = "";
@@ -1415,6 +1419,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0A42E061286DCD0C00A2C73D /* XCRemoteSwiftPackageReference "SwiftUIPager" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/fermoya/SwiftUIPager.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		0AC79183286B0AE00034A830 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/simibac/ConfettiSwiftUI.git";
@@ -1426,6 +1438,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0A42E062286DCD0C00A2C73D /* SwiftUIPager */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0A42E061286DCD0C00A2C73D /* XCRemoteSwiftPackageReference "SwiftUIPager" */;
+			productName = SwiftUIPager;
+		};
 		0AC79184286B0AE00034A830 /* ConfettiSwiftUI */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0AC79183286B0AE00034A830 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */;

--- a/Sofa.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sofa.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "8d3a15d0aa2991e0761749b767ef8d89bca6275a",
         "version" : "1.0.1"
       }
+    },
+    {
+      "identity" : "swiftuipager",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/fermoya/SwiftUIPager.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "669d20f0ab90dc6cac5aadbb8462505875805459"
+      }
     }
   ],
   "version" : 2

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -18,11 +18,12 @@ struct HomeView: View {
           ScrollView{
             LazyVStack{
               EventList()
+                .frame(height: 64)
             }
             .padding(EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 0))
             .overlay(Rectangle().frame(width: nil, height: 1, alignment: .top).foregroundColor(Color(hex: "EDEADF")), alignment: .top)
             .overlay(Rectangle().frame(width: nil, height: 1, alignment: .bottom).foregroundColor(Color(hex: "EDEADF")), alignment: .bottom)
-            .background(Color(hex: "EDEADF"))
+            .background(Color(hex: "F5F2E9"))
             ChatList()
           }// ScrollView
           .background(Color(hex: "F9F7EF"))

--- a/Sofa/Sources/View/Home/SubViews/EventList.swift
+++ b/Sofa/Sources/View/Home/SubViews/EventList.swift
@@ -6,34 +6,64 @@
 //
 
 import SwiftUI
+import SwiftUIPager
 
 struct EventList: View {
   
   @ObservedObject var eventViewModel = EventViewModel()
+  @StateObject var page: Page = .first()
+  @State var alignment: SofaPositionAlignment = .start
   
   var body: some View {
-    ScrollView(.horizontal, showsIndicators: false) {
-      LazyHStack(spacing: 16) {
-        
-        ForEach(Array(zip(eventViewModel.events.indices, eventViewModel.events)), id: \.0){ index, event in
-          if index == 0{ // 첫번째 row
-            EventRow(event)
-              .frame(width: Screen.maxWidth - 32 - 40)
-              .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0))
-          }
-          else if index == eventViewModel.events.count - 1{ // 마지막 row
-            EventRow(event)
-              .frame(width: Screen.maxWidth - 32 - 40)
-              .padding(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 16))
-          }
-          else{
-            EventRow(event)
-              .frame(width: Screen.maxWidth - 32 - 40)
-          }
+    Pager(page: page,
+          data: eventViewModel.events.indices,
+          id: \.self,
+          content: { index in
+      // create a page based on the data passed
+      EventRow(eventViewModel.events[index])
+    })
+    .onPageChanged({ (newIndex) in
+      if newIndex == 0 {
+        withAnimation {
+          self.alignment = .justified
         }
       }
+      else if newIndex == eventViewModel.events.count {
+        withAnimation {
+          self.alignment = .end
+        }
+      }
+      else{
+        withAnimation {
+          self.alignment = .justified
+        }
+      }
+      
+    })
+    .alignment(PositionAlignment(alignment: self.alignment))
+    .singlePagination(ratio: 0.33, sensitivity: .high)
+    .preferredItemSize(CGSize(width: 318, height: 100))
+    .itemSpacing(16)
+    .background(Color(hex: "#F5F2E9"))
+  }
+}
+
+enum SofaPositionAlignment: String, CaseIterable{
+  case start
+  case justified
+  case end
+}
+
+extension PositionAlignment {
+  init(alignment: SofaPositionAlignment) {
+    switch alignment {
+    case .start:
+      self = .start(16)
+    case .end:
+      self = .end(16)
+    case .justified:
+      self = .justified(16)
     }
-    .background(Color(hex: "#EDEADF"))
   }
 }
 

--- a/Sofa/Sources/View/Home/SubViews/EventList.swift
+++ b/Sofa/Sources/View/Home/SubViews/EventList.swift
@@ -42,7 +42,7 @@ struct EventList: View {
     })
     .alignment(PositionAlignment(alignment: self.alignment))
     .singlePagination(ratio: 0.33, sensitivity: .high)
-    .preferredItemSize(CGSize(width: 318, height: 100))
+    .preferredItemSize(CGSize(width: Screen.maxWidth - 72, height: 100))
     .itemSpacing(16)
     .background(Color(hex: "#F5F2E9"))
   }

--- a/Sofa/Sources/View/Home/SubViews/Row/EventRow.swift
+++ b/Sofa/Sources/View/Home/SubViews/Row/EventRow.swift
@@ -54,6 +54,7 @@ struct EventRow: View {
     .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
     .background(Color.white)
     .cornerRadius(8)
+    .frame(height: 64)
     .overlay( // cornerRadius값이 있는 border 주기 위해
       RoundedRectangle(cornerRadius: 8)
           .stroke(Color(hex: "EDEADF"), lineWidth: 1)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 일정 List Pager 적용
- Device 별 EventRow 크기 최적화

🌱 PR 포인트
- SwiftUIPager(SPM)를 이용하여 일정 View 요구사항 적용하였습니다.

## 📸 스크린샷
|일정 Pager|
|:--:|
![Simulator Screen Recording - iPhone 13 - 2022-07-01 at 12 46 48](https://user-images.githubusercontent.com/70887135/176819562-3398b5b9-9f64-4850-8bf6-f92824853c3b.gif)
|위 스크린샷에서는 잘렸는지 마지막 Cell의 Padding 값이 달라보이네요. 사실 일정합니다. |

## 📮 관련 이슈
-  #35 
