### PR TITLE
[FEAT] 일정 상세뷰 UI 구현

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		6FC854012874522900988A44 /* TaskColorPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC854002874522900988A44 /* TaskColorPicker.swift */; };
 		6FE6D78928619A1D00E3C21E /* CustomDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE6D78828619A1D00E3C21E /* CustomDatePicker.swift */; };
 		6FE6D78B2861B1B100E3C21E /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE6D78A2861B1B100E3C21E /* DateValue.swift */; };
+		6FF836FD2879FDEB00B3A390 /* TaskDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF836FC2879FDEB00B3A390 /* TaskDetailView.swift */; };
 		C4667A2F284B6FF200A4A759 /* SofaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A2E284B6FF200A4A759 /* SofaApp.swift */; };
 		C4667A31284B6FF200A4A759 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A30284B6FF200A4A759 /* ContentView.swift */; };
 		C4667A33284B6FF400A4A759 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4667A32284B6FF400A4A759 /* Assets.xcassets */; };
@@ -206,6 +207,7 @@
 		6FC854002874522900988A44 /* TaskColorPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskColorPicker.swift; sourceTree = "<group>"; };
 		6FE6D78828619A1D00E3C21E /* CustomDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDatePicker.swift; sourceTree = "<group>"; };
 		6FE6D78A2861B1B100E3C21E /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
+		6FF836FC2879FDEB00B3A390 /* TaskDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetailView.swift; sourceTree = "<group>"; };
 		8E72770DE00FE8DC5BDC3054 /* Pods_Sofa_SofaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sofa_SofaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A5C5DA7B0EA0D195D6A129 /* Pods-SofaTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SofaTests.debug.xcconfig"; path = "Target Support Files/Pods-SofaTests/Pods-SofaTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C4667A2B284B6FF200A4A759 /* Sofa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sofa.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -490,6 +492,7 @@
 				6F3E3EBB286B1E3900EF7082 /* AppendTaskModalView.swift */,
 				6FC853C528743D8D00988A44 /* TaskTimePicker.swift */,
 				6FC854002874522900988A44 /* TaskColorPicker.swift */,
+				6FF836FC2879FDEB00B3A390 /* TaskDetailView.swift */,
 				6F964BB22875D3A5007FD6B1 /* ColorCircles.swift */,
 			);
 			path = SubViews;
@@ -1164,6 +1167,7 @@
 				C4EC31E128504F2B0049F2C4 /* AlbumList.swift in Sources */,
 				C4B8F2C12852912D0000B8CB /* AlbumPhotoAddList.swift in Sources */,
 				C4A9795B286067E200326ABC /* AudioRecorderURLViewModel.swift in Sources */,
+				6FF836FD2879FDEB00B3A390 /* TaskDetailView.swift in Sources */,
 				0A858CBC2855BC6600907019 /* Ex+Color.swift in Sources */,
 				C4A979A5286AE8BD00326ABC /* AlbumImageDetailView.swift in Sources */,
 				6F22E52A284B9D140069D268 /* HomeView.swift in Sources */,

--- a/Sofa/Sources/View/Calendar/CalendarView.swift
+++ b/Sofa/Sources/View/Calendar/CalendarView.swift
@@ -13,34 +13,19 @@ struct CalendarView: View {
   @State private var showAppendTaskModal: Bool = false
   
   var body: some View {
-    VStack(spacing: 0) {
-      HStack(spacing: 0){
-        Text("캘린더")
-          .font(.custom("Pretendard-Bold", size: 24))
-          .foregroundColor(Color(hex: "121619"))
-          .padding(EdgeInsets(top: 0, leading: 24, bottom: 12, trailing: 0))
-        Spacer()
-        Button(action: {
-          self.showAppendTaskModal.toggle()
-        }) {
-          Image(systemName: "plus")
-            .font(.system(size: 20))
-            .foregroundColor(Color(hex: "43A047"))
-            .padding(EdgeInsets(top: 0, leading: 0, bottom: 12, trailing: 31))
-        }
-        .sheet(isPresented: self.$showAppendTaskModal) {
-          AppendTaskModalView()
-        }
+    NavigationView {
+      VStack(spacing: 0) {
+        Rectangle()
+          .frame(height: 1.0, alignment: .bottom)
+          .foregroundColor(Color(hex: "EDEADF"))
+        
+        Color(hex: "FAF8F0")
+          .ignoresSafeArea()
+          .frame(height: 8)
+        
+        CustomDatePicker(currentDate: $currentDate)
       }
-      Rectangle()
-        .frame(height: 1.0, alignment: .bottom)
-        .foregroundColor(Color(hex: "EDEADF"))
-      
-      Color(hex: "FAF8F0")
-        .ignoresSafeArea()
-        .frame(height: 8)
-      
-      CustomDatePicker(currentDate: $currentDate)
+      .navigationBarWithIconButtonStyle(isButtonClick: $showAppendTaskModal, buttonColor: Color(hex: "43A047"), "캘린더", "plus")
     }
   }
 }

--- a/Sofa/Sources/View/Calendar/SubViews/CustomDatePicker.swift
+++ b/Sofa/Sources/View/Calendar/SubViews/CustomDatePicker.swift
@@ -12,6 +12,7 @@ struct CustomDatePicker: View {
   @Binding var currentDate: Date
   
   @State var currentMonth: Int = 0
+  @State var showTaskDetail = false
   
   var body: some View {
     VStack(spacing: 0){
@@ -118,6 +119,11 @@ struct CustomDatePicker: View {
                 }
               }
               .frame(maxWidth: .infinity, alignment: .leading)
+              .contentShape(Rectangle())
+              .onTapGesture {
+                self.showTaskDetail.toggle()
+              }
+              .fullScreenCover(isPresented: self.$showTaskDetail, content: TaskDetailView.init)
             }
           } else {
           }

--- a/Sofa/Sources/View/Calendar/SubViews/TaskDetailView.swift
+++ b/Sofa/Sources/View/Calendar/SubViews/TaskDetailView.swift
@@ -1,0 +1,181 @@
+//
+//  TaskDetailView.swift
+//  Sofa
+//
+//  Created by 임주민 on 2022/07/10.
+//
+
+import SwiftUI
+
+struct TaskDetailView: View {
+  @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+  
+  @FocusState var isTitleFocused: Bool
+  @FocusState var isMemoFocused: Bool
+  
+  @State private var title: String = ""
+  @State private var memo: String = ""
+  @State private var allDayToggle = false
+  
+  init() {
+    UITextView.appearance().backgroundColor = .clear
+  }
+  
+  var body: some View {
+    ZStack {
+      Color(.white).ignoresSafeArea()
+        .padding(EdgeInsets(top: 0, leading: 0, bottom: 400, trailing: 0))
+      Color(hex: "FAF8F0").ignoresSafeArea()
+        .padding(EdgeInsets(top: 500, leading: 0, bottom: 0, trailing: 0))
+      
+      VStack(spacing: 0){
+        
+        HStack(spacing: 0){
+          Text("이전")
+            .frame(height: 24)
+            .font(.custom("Pretendard-Medium", size: 16))
+            .foregroundColor(Color(hex: "43A047"))
+            .padding(.leading, 24)
+            .onTapGesture {
+              self.presentationMode.wrappedValue.dismiss()
+            }
+          Spacer()
+          
+          Text("일정 상세")
+            .frame(height: 24)
+            .font(.custom("Pretendard-Bold", size: 16))
+            .foregroundColor(Color(hex: "121619"))
+          Spacer()
+          
+          Text("수정")
+            .frame(height: 24)
+            .font(.custom("Pretendard-Medium", size: 16))
+            .foregroundColor(Color(.black).opacity(0.4))
+            .padding(.trailing, 24)
+            .onTapGesture {
+              self.presentationMode.wrappedValue.dismiss()
+            }
+        }
+        Rectangle()
+          .frame(width:Screen.maxWidth, height: 1)
+          .foregroundColor(Color(hex: "EDEADF"))
+          .padding(.top,9)
+        Rectangle()
+          .frame(width: Screen.maxWidth, height: 7)
+          .foregroundColor(Color(hex: "FAF8F0"))
+        
+        ScrollView {
+          LazyVStack(spacing: 0) {
+            
+            Group {
+              TextField("", text: $title)
+                .placeholder(shouldShow: title.isEmpty) {
+                  Text("제목")
+                    .font(.custom("Pretendard-Medium", size: 18))
+                    .foregroundColor(Color(hex: "121619").opacity(0.4))
+                }
+                .customTextField(padding: 12)
+                .disableAutocorrection(true)
+                .frame(height: 48)
+                .background(isTitleFocused ? Color.white : Color(hex: "FAF8F0"))
+                .highlightTextField(firstLineWidth: isTitleFocused ? 1 : 0, secondLineWidth: isTitleFocused ? 4 : 0)
+                .cornerRadius(6)
+                .focused($isTitleFocused)
+                .padding(EdgeInsets(top: 16, leading: 16, bottom: 12, trailing: 16))
+                .modifier(DismissingKeyboard())
+                .onAppear {
+                  UIApplication.shared.hideKeyboard()
+                }
+            }
+            
+            // 색상
+            TaskColorPicker()
+            Rectangle()
+              .frame(width:Screen.maxWidth, height: 1)
+              .foregroundColor(Color(hex: "EDEADF"))
+            Rectangle()
+              .frame(width: Screen.maxWidth, height: 7)
+              .foregroundColor(Color(hex: "FAF8F0"))
+  
+            Group {
+              VStack(spacing: 0) {
+                // 하루종일
+                HStack(spacing: 0) {
+                  Image(systemName: "hourglass.tophalf.filled")
+                    .font(.system(size: 20))
+                    .frame(width: 24, height: 24)
+                    .foregroundColor(Color(hex:"4CAF50"))
+                    .padding(.trailing, 10)
+                  Text("하루 종일")
+                    .font(.custom("Pretendard-Medium", size: 16))
+                    .foregroundColor(Color(hex: "121619"))
+                  Toggle("", isOn: $allDayToggle)
+                  Spacer()
+                }.padding(.bottom, 24)
+                
+                // 날짜
+                GeneralDatePickerView()
+                  .padding(.bottom, 12)
+                
+                // 시간
+                if !allDayToggle {
+                  TaskTimePicker()
+                    .padding(.bottom, 27)
+                }
+              }.padding(EdgeInsets(top: 27, leading: 19.5, bottom: 0, trailing: 16))
+              
+              Rectangle()
+                .frame(width: Screen.maxWidth, height: 1)
+                .foregroundColor(Color(hex: "EDEADF"))
+              Rectangle()
+                .frame(width: Screen.maxWidth, height: 8)
+                .foregroundColor(Color(hex: "FAF8F0"))
+            }.background(Color.white)
+            
+            // 메모
+            Group {
+              ZStack {
+                Rectangle()
+                  .frame(width: Screen.maxWidth, height: 160)
+                  .foregroundColor(Color.white)
+                Rectangle()
+                  .frame(height: 128)
+                  .foregroundColor(isMemoFocused ? Color.white : Color(hex: "FAF8F0"))
+                  .cornerRadius(6)
+                  .highlightTextField(firstLineWidth: isMemoFocused ? 1 : 0, secondLineWidth: isMemoFocused ? 4 : 0)
+                  .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                
+                TextEditor(text: $memo)
+                  .placeholder(shouldShow: memo.isEmpty) {
+                    Text("메모")
+                      .font(.custom("Pretendard-Medium", size: 18))
+                      .foregroundColor(Color.black.opacity(0.4))
+                      .padding(EdgeInsets(top: 10, leading: 3, bottom: 0, trailing: 16))
+                      .frame(height: 128, alignment: .topLeading)
+                  }
+                  .customTextField(padding: 9)
+                  .disableAutocorrection(true)
+                  .foregroundColor(Color(hex: "121619"))
+                  .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                  .frame(height: 128, alignment: .center)
+                  .focused($isMemoFocused)
+                  .modifier(DismissingKeyboard())
+              }
+              Rectangle()
+                .frame(width:Screen.maxWidth, height: 1)
+                .foregroundColor(Color(hex: "EDEADF"))
+            }
+            Spacer()
+          }
+        }
+      }
+      .padding(.top, 9)
+    }
+  }
+}
+
+struct TaskDetailView_Previews: PreviewProvider {
+  static var previews: some View {
+    TaskDetailView()
+  }
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 일정 상세뷰 UI 구현

🌱 PR 포인트
- 저번 '일정 추가뷰'와 거의 매우 흡사해서 그 PR때 보여드렸던 코드와 동일합니다.
- 조건에 따른 '이전', '수정' 버튼의 활성화는 아직 구현하지 않았습니다.
- 특정 일정을 눌렀을 때 그 일정에 대한 정보를 가져오는 작업은 서버 연결 때 하겠습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://user-images.githubusercontent.com/76610340/178119597-fb9eb003-c185-44eb-8ccb-7ff5fd5cdd60.gif" width="300">|


## 📮 관련 이슈
- Resolved: #67 
