### PR TITLE
[FEAT] 알림 View & 일정 View Tab 이동

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		0A4CFBA1285F870B000603A5 /* LibreBaskerville-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0A4CFBA0285F870B000603A5 /* LibreBaskerville-Regular.ttf */; };
 		0A858CBC2855BC6600907019 /* Ex+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A858CBB2855BC6600907019 /* Ex+Color.swift */; };
 		0A915DD3287A9A9B0055AD6D /* NotificationMock.json in Resources */ = {isa = PBXBuildFile; fileRef = 0A915DD2287A9A9B0055AD6D /* NotificationMock.json */; };
+		0A915DD5287A9B8C0055AD6D /* NotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A915DD4287A9B8C0055AD6D /* NotificationViewModel.swift */; };
+		0A915DD7287A9BA00055AD6D /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A915DD6287A9BA00055AD6D /* Notifications.swift */; };
 		0AAB367C2863816300A47B24 /* EventList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAB367B2863816300A47B24 /* EventList.swift */; };
 		0AAB367F286381C000A47B24 /* HomeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAB367E286381C000A47B24 /* HomeInfo.swift */; };
 		0AAB36812864287E00A47B24 /* EventRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAB36802864287E00A47B24 /* EventRow.swift */; };
@@ -169,6 +171,8 @@
 		0A4CFBA22860C963000603A5 /* Sofa.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sofa.entitlements; sourceTree = "<group>"; };
 		0A858CBB2855BC6600907019 /* Ex+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Color.swift"; sourceTree = "<group>"; };
 		0A915DD2287A9A9B0055AD6D /* NotificationMock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NotificationMock.json; sourceTree = "<group>"; };
+		0A915DD4287A9B8C0055AD6D /* NotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewModel.swift; sourceTree = "<group>"; };
+		0A915DD6287A9BA00055AD6D /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		0AAB367B2863816300A47B24 /* EventList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventList.swift; sourceTree = "<group>"; };
 		0AAB367E286381C000A47B24 /* HomeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInfo.swift; sourceTree = "<group>"; };
 		0AAB36802864287E00A47B24 /* EventRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventRow.swift; sourceTree = "<group>"; };
@@ -345,6 +349,7 @@
 				0AAB36F22865F32400A47B24 /* EventViewModel.swift */,
 				0A2887F12870A646000A72F2 /* ChatViewModel.swift */,
 				0AE492012876A8DC00341D35 /* HistoryViewModel.swift */,
+				0A915DD4287A9B8C0055AD6D /* NotificationViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -427,6 +432,7 @@
 				6FE6D78A2861B1B100E3C21E /* DateValue.swift */,
 				6F0974342861E53A0000956C /* CalendarTask.swift */,
 				0AE492052876A9B000341D35 /* HistoryInfo.swift */,
+				0A915DD6287A9BA00055AD6D /* Notifications.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1147,6 +1153,7 @@
 				C495F61F285BC2C8009B3BDE /* AudioBarView.swift in Sources */,
 				C495F5F12855C3AA009B3BDE /* AlbumTypeRow.swift in Sources */,
 				6FE6D78928619A1D00E3C21E /* CustomDatePicker.swift in Sources */,
+				0A915DD5287A9B8C0055AD6D /* NotificationViewModel.swift in Sources */,
 				C495F5EF2855C17C009B3BDE /* AlbumType.swift in Sources */,
 				0AE492022876A8DC00341D35 /* HistoryViewModel.swift in Sources */,
 				0AE4921228780B0400341D35 /* Ex+UINavigationController.swift in Sources */,
@@ -1184,6 +1191,7 @@
 				6F22E52A284B9D140069D268 /* HomeView.swift in Sources */,
 				6F7340BC28741A4800707AB7 /* GeneralDatePickerView.swift in Sources */,
 				C4B8F2A82851CAD50000B8CB /* HiddenTabBar.swift in Sources */,
+				0A915DD7287A9BA00055AD6D /* Notifications.swift in Sources */,
 				C4B8F2AE2851CB1F0000B8CB /* Ex+UITabBar.swift in Sources */,
 				6F22E532284B9D330069D268 /* Network.swift in Sources */,
 				0AE492062876A9B000341D35 /* HistoryInfo.swift in Sources */,

--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0A4CFB9F285F8706000603A5 /* LibreBaskerville-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0A4CFB9E285F8706000603A5 /* LibreBaskerville-Bold.ttf */; };
 		0A4CFBA1285F870B000603A5 /* LibreBaskerville-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0A4CFBA0285F870B000603A5 /* LibreBaskerville-Regular.ttf */; };
 		0A858CBC2855BC6600907019 /* Ex+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A858CBB2855BC6600907019 /* Ex+Color.swift */; };
+		0A915DD3287A9A9B0055AD6D /* NotificationMock.json in Resources */ = {isa = PBXBuildFile; fileRef = 0A915DD2287A9A9B0055AD6D /* NotificationMock.json */; };
 		0AAB367C2863816300A47B24 /* EventList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAB367B2863816300A47B24 /* EventList.swift */; };
 		0AAB367F286381C000A47B24 /* HomeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAB367E286381C000A47B24 /* HomeInfo.swift */; };
 		0AAB36812864287E00A47B24 /* EventRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAB36802864287E00A47B24 /* EventRow.swift */; };
@@ -167,6 +168,7 @@
 		0A4CFBA0285F870B000603A5 /* LibreBaskerville-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "LibreBaskerville-Regular.ttf"; sourceTree = "<group>"; };
 		0A4CFBA22860C963000603A5 /* Sofa.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sofa.entitlements; sourceTree = "<group>"; };
 		0A858CBB2855BC6600907019 /* Ex+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+Color.swift"; sourceTree = "<group>"; };
+		0A915DD2287A9A9B0055AD6D /* NotificationMock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = NotificationMock.json; sourceTree = "<group>"; };
 		0AAB367B2863816300A47B24 /* EventList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventList.swift; sourceTree = "<group>"; };
 		0AAB367E286381C000A47B24 /* HomeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInfo.swift; sourceTree = "<group>"; };
 		0AAB36802864287E00A47B24 /* EventRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventRow.swift; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 				C4B8F2BB285289A20000B8CB /* MockData.swift */,
 				0A2887F32870A69F000A72F2 /* ChatInfoMock.json */,
 				0AE492032876A8F600341D35 /* HistoryMock.json */,
+				0A915DD2287A9A9B0055AD6D /* NotificationMock.json */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -991,6 +994,7 @@
 				0A4CFB9D285F85C8000603A5 /* Pretendard-Regular.otf in Resources */,
 				0A4CFB99285F85C8000603A5 /* Pretendard-Bold.otf in Resources */,
 				0AE492042876A8F600341D35 /* HistoryMock.json in Resources */,
+				0A915DD3287A9A9B0055AD6D /* NotificationMock.json in Resources */,
 				0A4CFB9B285F85C8000603A5 /* Pretendard-ExtraLight.otf in Resources */,
 				0A4CFB9F285F8706000603A5 /* LibreBaskerville-Bold.ttf in Resources */,
 				0ABA0C1B28579769005F2C6A /* 15025-bed.json in Resources */,

--- a/Sofa/Configuration/Mock/NotificationMock.json
+++ b/Sofa/Configuration/Mock/NotificationMock.json
@@ -3,19 +3,61 @@
     {
       "type" : "CALENDAR",
       "user" : "엄마 아빠 딸",
-      "targetId" : 3,
+      "targetId" : 0,
       "createdDate" : "2022-06-05 22:30"
     },
     {
       "type" : "ALBUM",
       "user" : "엄마 아빠 딸",
-      "targetId" : 23,
+      "targetId" : 1,
       "createdDate" : "2022-06-05 20:30"
     },
     {
       "type" : "ALBUM",
       "user" : "엄마 아빠 딸",
-      "targetId" : 23,
+      "targetId" : 2,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 3,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 4,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 5,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 6,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 7,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 8,
+      "createdDate" : "2022-06-05 8:30"
+    },
+    {
+      "type" : "ALBUM",
+      "user" : "엄마 아빠 딸",
+      "targetId" : 9,
       "createdDate" : "2022-06-05 8:30"
     }
   ]

--- a/Sofa/Configuration/Mock/NotificationMock.json
+++ b/Sofa/Configuration/Mock/NotificationMock.json
@@ -8,31 +8,31 @@
     },
     {
       "type" : "ALBUM",
-      "user" : "엄마 아빠 딸",
+      "user" : "엄마",
       "targetId" : 1,
       "createdDate" : "2022-06-05 20:30"
     },
     {
       "type" : "ALBUM",
-      "user" : "엄마 아빠 딸",
+      "user" : "딸",
       "targetId" : 2,
       "createdDate" : "2022-06-05 8:30"
     },
     {
-      "type" : "ALBUM",
-      "user" : "엄마 아빠 딸",
+      "type" : "CALENDAR",
+      "user" : "아빠",
       "targetId" : 3,
       "createdDate" : "2022-06-05 8:30"
     },
     {
       "type" : "ALBUM",
-      "user" : "엄마 아빠 딸",
+      "user" : "엄마",
       "targetId" : 4,
       "createdDate" : "2022-06-05 8:30"
     },
     {
-      "type" : "ALBUM",
-      "user" : "엄마 아빠 딸",
+      "type" : "CALENDAR",
+      "user" : "딸",
       "targetId" : 5,
       "createdDate" : "2022-06-05 8:30"
     },
@@ -43,13 +43,13 @@
       "createdDate" : "2022-06-05 8:30"
     },
     {
-      "type" : "ALBUM",
+      "type" : "CALENDAR",
       "user" : "엄마 아빠 딸",
       "targetId" : 7,
       "createdDate" : "2022-06-05 8:30"
     },
     {
-      "type" : "ALBUM",
+      "type" : "CALENDAR",
       "user" : "엄마 아빠 딸",
       "targetId" : 8,
       "createdDate" : "2022-06-05 8:30"

--- a/Sofa/Configuration/Mock/NotificationMock.json
+++ b/Sofa/Configuration/Mock/NotificationMock.json
@@ -2,19 +2,19 @@
   "notifications" : [
     {
       "type" : "CALENDAR",
-      "content" : "엄마 아빠 딸 님이 새로운 일정을 등록했습니다.",
+      "user" : "엄마 아빠 딸",
       "targetId" : 3,
       "createdDate" : "2022-06-05 22:30"
     },
     {
       "type" : "ALBUM",
-      "content" : "엄마 아빠 딸 님이 새로운 사진을 업로드 했습니다.",
+      "user" : "엄마 아빠 딸",
       "targetId" : 23,
       "createdDate" : "2022-06-05 20:30"
     },
     {
       "type" : "ALBUM",
-      "content" : "엄마 아빠 딸 님이 새로운 사진을 업로드 했습니다.",
+      "user" : "엄마 아빠 딸",
       "targetId" : 23,
       "createdDate" : "2022-06-05 8:30"
     }

--- a/Sofa/Configuration/Mock/NotificationMock.json
+++ b/Sofa/Configuration/Mock/NotificationMock.json
@@ -1,0 +1,22 @@
+{
+  "notifications" : [
+    {
+      "type" : "CALENDAR",
+      "content" : "엄마 아빠 딸 님이 새로운 일정을 등록했습니다.",
+      "targetId" : 3,
+      "createdDate" : "2022-06-05 22:30"
+    },
+    {
+      "type" : "ALBUM",
+      "content" : "엄마 아빠 딸 님이 새로운 사진을 업로드 했습니다.",
+      "targetId" : 23,
+      "createdDate" : "2022-06-05 20:30"
+    },
+    {
+      "type" : "ALBUM",
+      "content" : "엄마 아빠 딸 님이 새로운 사진을 업로드 했습니다.",
+      "targetId" : 23,
+      "createdDate" : "2022-06-05 8:30"
+    }
+  ]
+}

--- a/Sofa/Sources/Models/Notifications.swift
+++ b/Sofa/Sources/Models/Notifications.swift
@@ -1,0 +1,31 @@
+//
+//  Notifications.swift
+//  Sofa
+//
+//  Created by 양유진 on 2022/07/10.
+//
+
+import Foundation
+
+struct Notifications: Decodable {
+  var notifications: [Notification]
+}
+
+struct Notification: Decodable {
+  var type: String
+  var user: String
+  var targetId: Int
+  var createdDate: String
+  
+  static func getDummy() -> Self{
+    return Notification(type: "CALENDAR", user: "엄마 아빠 딸", targetId: 3, createdDate: "2022-06-05 22:30")
+  }
+  
+  var descriptionUser: String{
+    return "\(user)"
+  }
+  
+  var descriptionDate: String{
+    return "\(createdDate)"
+  }
+}

--- a/Sofa/Sources/Models/Notifications.swift
+++ b/Sofa/Sources/Models/Notifications.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct Notifications: Decodable {
+struct Notifications: Decodable, Hashable {
   var notifications: [Notification]
 }
 
-struct Notification: Decodable {
+struct Notification: Decodable, Hashable {
   var type: String
   var user: String
   var targetId: Int

--- a/Sofa/Sources/View/ContentView.swift
+++ b/Sofa/Sources/View/ContentView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum Tab {
+enum Tab{
   case home
   case calendar
   case album

--- a/Sofa/Sources/View/ContentView.swift
+++ b/Sofa/Sources/View/ContentView.swift
@@ -7,19 +7,19 @@
 
 import SwiftUI
 
+enum Tab {
+  case home
+  case calendar
+  case album
+  case setting
+}
+
 struct ContentView: View {
   @State private var selection: Tab = .home
-  
-  enum Tab {
-    case home
-    case calendar
-    case album
-    case setting
-  }
-  
+    
   var body: some View {
     TabView(selection: $selection) {
-      HomeView()
+      HomeView(selectionType: $selection)
         .tabItem {
           Image(systemName: "person.3.fill")
           Text("홈")

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
   @ObservedObject var eventViewModel = EventViewModel()
   @State var gotoAlarm = false
   @State var showModal = false
+  @Binding var selectionType: Tab
   
   var body: some View {
     ZStack {
@@ -21,7 +22,7 @@ struct HomeView: View {
             Text("\(eventViewModel.hometitle)")
               .font(.custom("Pretendard-Bold", size: 24))
             Spacer()
-            NavigationLink(destination: NotificationView().onAppear{UITabBar.hideTabBar(animated: false)}.onDisappear{UITabBar.showTabBar(animated: false)}){
+            NavigationLink(destination: NotificationView().onAppear{UITabBar.hideTabBar(animated: false)}){
               Image(systemName: "bell")
                 .resizable()
                 .foregroundColor(Color.black)
@@ -39,7 +40,7 @@ struct HomeView: View {
           .background(.white)
           ScrollView{
             LazyVStack{
-              EventList(eventViewModel: eventViewModel, page: .first(), alignment: .start)
+              EventList(eventViewModel: eventViewModel, page: .first(), alignment: .start, selectionType: $selectionType)
                 .frame(height: eventViewModel.events.count == 0 ? 0 : 64)
                 .padding(.vertical, eventViewModel.events.count == 0 ? 0 : 16)
             }
@@ -60,6 +61,9 @@ struct HomeView: View {
         }// VStack
         .background(Color(hex: "F9F7EF"))
         .navigationBarHidden(true)
+        .onAppear{
+          UITabBar.showTabBar(animated: false)
+        }
       }// NavigationView
       .accentColor(Color(hex: "43A047"))
       
@@ -75,7 +79,7 @@ struct HomeView: View {
 
 struct HomeView_Previews: PreviewProvider {
   static var previews: some View {
-    HomeView()
+    HomeView(selectionType: .constant(.home))
   }
 }
 

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -22,7 +22,7 @@ struct HomeView: View {
             Text("\(eventViewModel.hometitle)")
               .font(.custom("Pretendard-Bold", size: 24))
             Spacer()
-            NavigationLink(destination: NotificationView().onAppear{UITabBar.hideTabBar(animated: false)}){
+            NavigationLink(destination: NotificationView(selectionType: $selectionType).onAppear{UITabBar.hideTabBar(animated: false)}){
               Image(systemName: "bell")
                 .resizable()
                 .foregroundColor(Color.black)

--- a/Sofa/Sources/View/Home/NotificationView.swift
+++ b/Sofa/Sources/View/Home/NotificationView.swift
@@ -8,15 +8,14 @@
 import SwiftUI
 
 struct NotificationView: View {
+  @Environment(\.presentationMode) var presentationMode
   @State var gotoAlarmSetting = false
   @ObservedObject var notificationViewModel = NotificationViewModel()
+  @Binding var selectionType: Tab
+  
   
   var periodArr = ["오늘", "이번 주", "이번 달"]
   var taskDict = ["CALENDAR" : "일정", "ALBUM" : "사진"]
-  
-  init() {
-    UINavigationBar.appearance().backgroundColor = .white
-  }
   
   // 섹션 별로 나눈 notification
   let today = NotificationViewModel().notification[0..<3]
@@ -46,7 +45,19 @@ struct NotificationView: View {
 //            } label: {
 //              alarmRow(notification)
 //            }
-            alarmRow(notification)
+            NotificationRow(notification)
+              .onTapGesture {
+                if notification.type == "CALENDAR"{
+                  self.selectionType = .calendar
+                  print("CALENDAR")
+                }else if notification.type == "ALBUM"{
+                  self.selectionType = .album
+                  print("ALBUM")
+                }
+                
+                self.presentationMode.wrappedValue.dismiss()
+                
+              }
 
           }
           .toolbar {
@@ -87,8 +98,8 @@ struct NotificationView: View {
      }
   }
   
-  //MARK: - alarmRow
-  func alarmRow(_ notification: Notification) ->some View{
+  //MARK: - NotificationRow
+  func NotificationRow(_ notification: Notification) ->some View{
     HStack(alignment: .top){
       Image("lionprofile")
         .resizable()
@@ -113,9 +124,9 @@ struct NotificationView: View {
     .background(Color.white)
   }
 }
-
-struct NotificationView_Previews: PreviewProvider {
-  static var previews: some View {
-    NotificationView()
-  }
-}
+//
+//struct NotificationView_Previews: PreviewProvider {
+//  static var previews: some View {
+//    NotificationView()
+//  }
+//}

--- a/Sofa/Sources/View/Home/NotificationView.swift
+++ b/Sofa/Sources/View/Home/NotificationView.swift
@@ -75,7 +75,7 @@ struct NotificationView: View {
         .padding(EdgeInsets(top: 0, leading: 14.5, bottom: 0, trailing: 14.5))
       Spacer()
 //                .frame(width: 22.5)
-      LabelView(text: "우리집 보스 님이 새로운 일정을 등록했습니다.")
+      LabelView(text: "우리집 보스 님이 새로운 사진을 등록했습니다.")
         .font(.custom("Pretendard-Bold", size: 14))
         .foregroundColor(Color(hex: "121619"))
         .frame(height: 40)

--- a/Sofa/Sources/View/Home/NotificationView.swift
+++ b/Sofa/Sources/View/Home/NotificationView.swift
@@ -9,37 +9,44 @@ import SwiftUI
 
 struct NotificationView: View {
   @State var gotoAlarmSetting = false
-//  @Binding var tabbarHeight: Int
+  @ObservedObject var notificationViewModel = NotificationViewModel()
+  
   var periodArr = ["오늘", "이번 주", "이번 달"]
+  var taskDict = ["CALENDAR" : "일정", "ALBUM" : "사진"]
   
   init() {
     UINavigationBar.appearance().backgroundColor = .white
-//    self._tabbarHeight = tabbarHeight
   }
+  
+  // 섹션 별로 나눈 notification
+  let today = NotificationViewModel().notification[0..<3]
+  let thisweek = NotificationViewModel().notification[3..<6]
+  let thismonth = NotificationViewModel().notification[6..<9]
   
   var body: some View {
     ScrollView {
       LazyVStack(spacing: 0) {
-        ForEach(periodArr, id: \.self) { period in
+        ForEach(periodArr.indices, id: \.self) { i in
           Rectangle()
             .foregroundColor(Color(hex: "FAF8F0"))
             .frame(height: 8)
           HStack {
             Spacer()
               .frame(width: 16)
-            Text("\(period)")
+            Text("\(periodArr[i])")
               .font(.custom("Pretendard-Bold", size: 13))
               .foregroundColor(Color(hex: "999899"))
             Spacer()
           }
           .frame(height: 52)
           .background(Color.white)
-          ForEach(0..<3) { notification in
-            NavigationLink {
-              AlbumImageDetailView(image: UIImage(imageLiteralResourceName: "photo01"), index: 0)
-            } label: {
-              alarmRow(notification)
-            }
+          ForEach(Array(zip(getPeriodType(periodArr[i]).indices, getPeriodType(periodArr[i]))), id: \.1) { idx, notification in
+//            NavigationLink {
+//              AlbumImageDetailView(image: UIImage(imageLiteralResourceName: "photo01"), index: 0)
+//            } label: {
+//              alarmRow(notification)
+//            }
+            alarmRow(notification)
 
           }
           .toolbar {
@@ -66,16 +73,29 @@ struct NotificationView: View {
     .edgesIgnoringSafeArea([.bottom])
 
   }
+  
+  func getPeriodType(_ periodType: String) -> ArraySlice<Notification>{
+     switch periodType {
+     case "오늘":
+       return today
+     case "이번 주":
+       return thisweek
+     case "이번 달":
+        return thismonth
+     default:
+       return today
+     }
+  }
+  
   //MARK: - alarmRow
-    func alarmRow(_ notification: Int) ->some View{
+  func alarmRow(_ notification: Notification) ->some View{
     HStack(alignment: .top){
       Image("lionprofile")
         .resizable()
         .frame(width: 51, height: 52.5)
         .padding(EdgeInsets(top: 0, leading: 14.5, bottom: 0, trailing: 14.5))
       Spacer()
-//                .frame(width: 22.5)
-      LabelView(text: "우리집 보스 님이 새로운 사진을 등록했습니다.")
+      LabelView(text: "\(notification.user) 님이 새로운 \(taskDict[notification.type] ?? "")을 등록했습니다.")
         .font(.custom("Pretendard-Bold", size: 14))
         .foregroundColor(Color(hex: "121619"))
         .frame(height: 40)

--- a/Sofa/Sources/View/Home/NotificationView.swift
+++ b/Sofa/Sources/View/Home/NotificationView.swift
@@ -35,7 +35,12 @@ struct NotificationView: View {
           .frame(height: 52)
           .background(Color.white)
           ForEach(0..<3) { notification in
-            alarmRow(notification)
+            NavigationLink {
+              AlbumImageDetailView(image: UIImage(imageLiteralResourceName: "photo01"), index: 0)
+            } label: {
+              alarmRow(notification)
+            }
+
           }
           .toolbar {
             Button {

--- a/Sofa/Sources/View/Home/SubViews/EventList.swift
+++ b/Sofa/Sources/View/Home/SubViews/EventList.swift
@@ -13,6 +13,7 @@ struct EventList: View {
   @ObservedObject var eventViewModel = EventViewModel()
   @StateObject var page: Page = .first()
   @State var alignment: SofaPositionAlignment = .start
+  @Binding var selectionType: Tab
   
   var body: some View {
     Pager(page: page,
@@ -22,6 +23,9 @@ struct EventList: View {
       // create a page based on the data passed
       if eventViewModel.events.count > 0 {
         EventRow(eventViewModel.events[index])
+          .onTapGesture {
+            self.selectionType = .calendar
+          }
       }
     })
     .onPageChanged({ (newIndex) in
@@ -74,9 +78,9 @@ extension PositionAlignment {
     }
   }
 }
-
-struct EventList_Previews: PreviewProvider {
-  static var previews: some View {
-    EventList()
-  }
-}
+//
+//struct EventList_Previews: PreviewProvider {
+//  static var previews: some View {
+//    EventList()
+//  }
+//}

--- a/Sofa/Sources/View/Home/SubViews/Row/EventRow.swift
+++ b/Sofa/Sources/View/Home/SubViews/Row/EventRow.swift
@@ -51,9 +51,6 @@ struct EventRow: View {
         }
       }// HStack
     }// HStack
-    .onTapGesture {
-      print("Go To Calendar Tab")
-    }
     .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
     .background(Color.white)
     .cornerRadius(8)

--- a/Sofa/Sources/View/Home/ViewModel/NotificationViewModel.swift
+++ b/Sofa/Sources/View/Home/ViewModel/NotificationViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationViewModel.swift
+//  Sofa
+//
+//  Created by 양유진 on 2022/07/10.
+//
+
+import Foundation

--- a/Sofa/Sources/View/Home/ViewModel/NotificationViewModel.swift
+++ b/Sofa/Sources/View/Home/ViewModel/NotificationViewModel.swift
@@ -6,3 +6,47 @@
 //
 
 import Foundation
+import Combine
+
+class NotificationViewModel: ObservableObject{
+  
+  //MARK: Properties
+  var subscription = Set<AnyCancellable>()
+  
+  @Published var notification = [Notification]()
+  
+  var baseUrl = ""
+  
+  init(){
+    fetchNotification()
+  }
+  
+  func fetchNotification(){
+    
+    guard let path = Bundle.main.path(forResource: "NotificationMock", ofType: "json")
+    else {
+      fatalError("Couldn't find file in main bundle.")
+    }
+    
+    guard let jsonString = try? String(contentsOfFile: path) else {
+      return
+    }
+    
+    
+    if let data = jsonString.data(using: .utf8){
+      Just(data)
+        .decode(type: Notifications.self, decoder: JSONDecoder())
+        .map{ $0.notifications }
+        .sink(receiveCompletion: { completion in
+//          print("데이터스트림 완료")
+          
+        }, receiveValue: { receivedValue in
+//          print("받은 값: \(receivedValue.count)")
+          self.notification = receivedValue
+        }).store(in: &subscription)
+    }
+    
+    
+  }
+}
+


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 일정 List Row 클릭 시 Calendar Tab으로 이동
- 알림 View에서 Task 별로 Album OR Calendar Tab으로 이동

🌱 PR 포인트
- Tab의 이동을 위하여 ContentView의 tab enum을 ContentView 구조체 밖으로 뺐습니다.
- ContentView 내 TabView에 Selection Binding을 추가하여 Tab 이동을 구현하였습니다.
- 어제 말씀드린 로직이 아닌 기존 로직으로 우선 구현하였습니다. 

## 📸 스크린샷
|일정 View|알림 View|
|:--:|:--:|
|![Simulator Screen Recording - iPhone 13 - 2022-07-10 at 20 57 49](https://user-images.githubusercontent.com/70887135/178143867-f8806a86-ea9d-44a7-aa2a-ad99d1352691.gif)|![Simulator Screen Recording - iPhone 13 - 2022-07-10 at 20 58 18](https://user-images.githubusercontent.com/70887135/178143881-e5a9a64d-1ff5-4909-b6c0-09ece621b4a7.gif)|

## 📮 관련 이슈
- Resolved: #72 
