### PR TITLE
[CHORE] Responder 항상 TextEditor + Placeholder Binding

### DIFF
--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -14,6 +14,7 @@ struct HomeView: View {
   @State var showModal = false
   @State var showMessageView = false
   @Binding var selectionType: Tab
+  @State var placeholder = "가족에게 인사를 남겨보세요."
   
   var body: some View {
     ZStack {
@@ -69,7 +70,7 @@ struct HomeView: View {
       .accentColor(Color(hex: "43A047"))
       
       if showMessageView{
-        MessageView($showMessageView)
+        MessageView($showMessageView, $placeholder)
           .background(BackgroundCleanerView())
       }
       


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- MessageView의 TextEditor의 Responder 항상 TextEditor로 유지
- MessageView의 PlacerHolder Binding 처리

🌱 PR 포인트
- @GeonHyeongKim님 Placeholder @Binding 처리 해놨습니다~

## 📮 관련 이슈
- #80