### PR TITLE
[FEAT] 앨범 제목 수정 UI

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		6FF89F13287EF7A60009D934 /* RegisterFinishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF89F12287EF7A60009D934 /* RegisterFinishView.swift */; };
 		6FF89F15287F011C0009D934 /* RegisterFamilyFinishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF89F14287F011C0009D934 /* RegisterFamilyFinishView.swift */; };
 		C4400034288191B8007D0C20 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4400033288191B8007D0C20 /* APIConstants.swift */; };
+		C440003728819838007D0C20 /* AlbumTitleEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C440003628819838007D0C20 /* AlbumTitleEditView.swift */; };
 		C4667A2F284B6FF200A4A759 /* SofaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A2E284B6FF200A4A759 /* SofaApp.swift */; };
 		C4667A31284B6FF200A4A759 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A30284B6FF200A4A759 /* ContentView.swift */; };
 		C4667A33284B6FF400A4A759 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4667A32284B6FF400A4A759 /* Assets.xcassets */; };
@@ -252,6 +253,7 @@
 		8E72770DE00FE8DC5BDC3054 /* Pods_Sofa_SofaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sofa_SofaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A5C5DA7B0EA0D195D6A129 /* Pods-SofaTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SofaTests.debug.xcconfig"; path = "Target Support Files/Pods-SofaTests/Pods-SofaTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C4400033288191B8007D0C20 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		C440003628819838007D0C20 /* AlbumTitleEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTitleEditView.swift; sourceTree = "<group>"; };
 		C4667A2B284B6FF200A4A759 /* Sofa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sofa.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4667A2E284B6FF200A4A759 /* SofaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SofaApp.swift; sourceTree = "<group>"; };
 		C4667A30284B6FF200A4A759 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 				C4667A84284BA97000A4A759 /* SubViews */,
 				C495F60F285B5F69009B3BDE /* ViewModel */,
 				C4EC31CE284F99BF0049F2C4 /* AlbumDetailView */,
+				C44000352881981C007D0C20 /* AlbumTitleEditView */,
 				C4A979A3286AE88E00326ABC /* AlbumImageDetailView */,
 				C481B6C72878746F005D6831 /* AlbumCommentView */,
 				C4B8F2BD2852908E0000B8CB /* AlbumPhotoAddView */,
@@ -582,6 +585,14 @@
 				639E791ADDF619043B6A741F /* Pods_SofaTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C44000352881981C007D0C20 /* AlbumTitleEditView */ = {
+			isa = PBXGroup;
+			children = (
+				C440003628819838007D0C20 /* AlbumTitleEditView.swift */,
+			);
+			path = AlbumTitleEditView;
 			sourceTree = "<group>";
 		};
 		C4667A22284B6FF200A4A759 = {
@@ -1258,6 +1269,7 @@
 				C4B8F2BC285289A30000B8CB /* MockData.swift in Sources */,
 				C4A9799A28682DF800326ABC /* RecordAuthorization.swift in Sources */,
 				0AAB36F32865F32400A47B24 /* EventViewModel.swift in Sources */,
+				C440003728819838007D0C20 /* AlbumTitleEditView.swift in Sources */,
 				C481B6D7287ADEAB005D6831 /* CommentViewModel.swift in Sources */,
 				C4B8F2C8285348980000B8CB /* AlbumPhotoLibrary.swift in Sources */,
 				C4EC31CB284F8CBB0049F2C4 /* Album.swift in Sources */,

--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		C4667A40284B6FF400A4A759 /* SofaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A3F284B6FF400A4A759 /* SofaTests.swift */; };
 		C4667A4A284B6FF400A4A759 /* SofaUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A49284B6FF400A4A759 /* SofaUITests.swift */; };
 		C4667A4C284B6FF400A4A759 /* SofaUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A4B284B6FF400A4A759 /* SofaUITestsLaunchTests.swift */; };
+		C46C56CE2881B40700677E63 /* AlbumTitleEditNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46C56CD2881B40600677E63 /* AlbumTitleEditNavigationBar.swift */; };
 		C481B6B72875D4E7005D6831 /* AlbumImageDetailNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481B6B62875D4E7005D6831 /* AlbumImageDetailNavigationBar.swift */; };
 		C481B6BC2875FD0A005D6831 /* Blur.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481B6BB2875FD0A005D6831 /* Blur.swift */; };
 		C481B6C1287607DB005D6831 /* AlbumImageDetailSettingBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481B6C0287607DB005D6831 /* AlbumImageDetailSettingBar.swift */; };
@@ -264,6 +265,7 @@
 		C4667A45284B6FF400A4A759 /* SofaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SofaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4667A49284B6FF400A4A759 /* SofaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SofaUITests.swift; sourceTree = "<group>"; };
 		C4667A4B284B6FF400A4A759 /* SofaUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SofaUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		C46C56CD2881B40600677E63 /* AlbumTitleEditNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTitleEditNavigationBar.swift; sourceTree = "<group>"; };
 		C481B6B62875D4E7005D6831 /* AlbumImageDetailNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImageDetailNavigationBar.swift; sourceTree = "<group>"; };
 		C481B6BB2875FD0A005D6831 /* Blur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blur.swift; sourceTree = "<group>"; };
 		C481B6C0287607DB005D6831 /* AlbumImageDetailSettingBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImageDetailSettingBar.swift; sourceTree = "<group>"; };
@@ -591,6 +593,7 @@
 			isa = PBXGroup;
 			children = (
 				C440003628819838007D0C20 /* AlbumTitleEditView.swift */,
+				C46C56CB2881B3DE00677E63 /* SubViews */,
 			);
 			path = AlbumTitleEditView;
 			sourceTree = "<group>";
@@ -702,6 +705,22 @@
 				C4A9799828682DE600326ABC /* Authorization */,
 			);
 			path = SubViews;
+			sourceTree = "<group>";
+		};
+		C46C56CB2881B3DE00677E63 /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+				C46C56CC2881B3EA00677E63 /* NavigationBar */,
+			);
+			path = SubViews;
+			sourceTree = "<group>";
+		};
+		C46C56CC2881B3EA00677E63 /* NavigationBar */ = {
+			isa = PBXGroup;
+			children = (
+				C46C56CD2881B40600677E63 /* AlbumTitleEditNavigationBar.swift */,
+			);
+			path = NavigationBar;
 			sourceTree = "<group>";
 		};
 		C481B6B42875D4BA005D6831 /* SubViews */ = {
@@ -1293,6 +1312,7 @@
 				C481B6BC2875FD0A005D6831 /* Blur.swift in Sources */,
 				C4B8F2AC2851CB0E0000B8CB /* Ex+UIView.swift in Sources */,
 				0A223B72285F75D6002203ED /* CustomText.swift in Sources */,
+				C46C56CE2881B40700677E63 /* AlbumTitleEditNavigationBar.swift in Sources */,
 				6F964BB32875D3A5007FD6B1 /* ColorCircles.swift in Sources */,
 				6FC853C628743D8D00988A44 /* TaskTimePicker.swift in Sources */,
 				C481B6CF28787A86005D6831 /* ModalBackGround.swift in Sources */,

--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		6FF89F11287EF3DA0009D934 /* RegisterFamilyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF89F10287EF3DA0009D934 /* RegisterFamilyView.swift */; };
 		6FF89F13287EF7A60009D934 /* RegisterFinishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF89F12287EF7A60009D934 /* RegisterFinishView.swift */; };
 		6FF89F15287F011C0009D934 /* RegisterFamilyFinishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF89F14287F011C0009D934 /* RegisterFamilyFinishView.swift */; };
+		C4400034288191B8007D0C20 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4400033288191B8007D0C20 /* APIConstants.swift */; };
 		C4667A2F284B6FF200A4A759 /* SofaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A2E284B6FF200A4A759 /* SofaApp.swift */; };
 		C4667A31284B6FF200A4A759 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A30284B6FF200A4A759 /* ContentView.swift */; };
 		C4667A33284B6FF400A4A759 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4667A32284B6FF400A4A759 /* Assets.xcassets */; };
@@ -125,7 +126,6 @@
 		C4A979A5286AE8BD00326ABC /* AlbumImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A979A4286AE8BD00326ABC /* AlbumImageDetailView.swift */; };
 		C4B4963528800DDF000C9E1F /* AlbumListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4963428800DDF000C9E1F /* AlbumListViewModel.swift */; };
 		C4B4963928801E5D000C9E1F /* AlbumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4963828801E5D000C9E1F /* AlbumManager.swift */; };
-		C4B4963B288041BE000C9E1F /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4963A288041BE000C9E1F /* APIConstants.swift */; };
 		C4B8F2952850DA1C0000B8CB /* AlbumActionSheetItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B8F2942850DA1C0000B8CB /* AlbumActionSheetItem.swift */; };
 		C4B8F29F285109410000B8CB /* AlbumActionSheetCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B8F29E285109410000B8CB /* AlbumActionSheetCard.swift */; };
 		C4B8F2A62851CABF0000B8CB /* ShowTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B8F2A52851CABF0000B8CB /* ShowTabBar.swift */; };
@@ -251,6 +251,7 @@
 		6FF89F14287F011C0009D934 /* RegisterFamilyFinishView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFamilyFinishView.swift; sourceTree = "<group>"; };
 		8E72770DE00FE8DC5BDC3054 /* Pods_Sofa_SofaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sofa_SofaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1A5C5DA7B0EA0D195D6A129 /* Pods-SofaTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SofaTests.debug.xcconfig"; path = "Target Support Files/Pods-SofaTests/Pods-SofaTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C4400033288191B8007D0C20 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		C4667A2B284B6FF200A4A759 /* Sofa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sofa.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4667A2E284B6FF200A4A759 /* SofaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SofaApp.swift; sourceTree = "<group>"; };
 		C4667A30284B6FF200A4A759 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -295,7 +296,6 @@
 		C4A979A4286AE8BD00326ABC /* AlbumImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImageDetailView.swift; sourceTree = "<group>"; };
 		C4B4963428800DDF000C9E1F /* AlbumListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewModel.swift; sourceTree = "<group>"; };
 		C4B4963828801E5D000C9E1F /* AlbumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumManager.swift; sourceTree = "<group>"; };
-		C4B4963A288041BE000C9E1F /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		C4B8F2942850DA1C0000B8CB /* AlbumActionSheetItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumActionSheetItem.swift; sourceTree = "<group>"; };
 		C4B8F29E285109410000B8CB /* AlbumActionSheetCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumActionSheetCard.swift; sourceTree = "<group>"; };
 		C4B8F2A52851CABF0000B8CB /* ShowTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowTabBar.swift; sourceTree = "<group>"; };
@@ -487,7 +487,7 @@
 			isa = PBXGroup;
 			children = (
 				C4B4963828801E5D000C9E1F /* AlbumManager.swift */,
-				C4B4963A288041BE000C9E1F /* APIConstants.swift */,
+				C4400033288191B8007D0C20 /* APIConstants.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1314,6 +1314,7 @@
 				C4A979A5286AE8BD00326ABC /* AlbumImageDetailView.swift in Sources */,
 				0A915DF7287B21E70055AD6D /* MessageView.swift in Sources */,
 				6F22E52A284B9D140069D268 /* HomeView.swift in Sources */,
+				C4400034288191B8007D0C20 /* APIConstants.swift in Sources */,
 				6F7340BC28741A4800707AB7 /* GeneralDatePickerView.swift in Sources */,
 				C4B8F2A82851CAD50000B8CB /* HiddenTabBar.swift in Sources */,
 				0A915DD7287A9BA00055AD6D /* Notifications.swift in Sources */,
@@ -1343,7 +1344,6 @@
 				C4EC31D0284F99F30049F2C4 /* AlbumDetailView.swift in Sources */,
 				C481B6C1287607DB005D6831 /* AlbumImageDetailSettingBar.swift in Sources */,
 				C481B6DC287AEF0E005D6831 /* Ex+String.swift in Sources */,
-				C4B4963B288041BE000C9E1F /* APIConstants.swift in Sources */,
 				C4A979A22869E40F00326ABC /* ToastMessage.swift in Sources */,
 				C4B8F29F285109410000B8CB /* AlbumActionSheetCard.swift in Sources */,
 				6FF89F15287F011C0009D934 /* RegisterFamilyFinishView.swift in Sources */,

--- a/Sofa/Configuration/Extensions/Ex+View.swift
+++ b/Sofa/Configuration/Extensions/Ex+View.swift
@@ -14,8 +14,8 @@ public extension View {
     return self.modifier(NavigationBarWithIconButtonStyle(isButtonClick: isButtonClick, title: title, buttonName: buttonName, buttonColor: buttonColor))
   }
   
-  func navigationBarWithTextButtonStyle(isNextClick: Binding<Bool>, isDisalbeNextButton: Binding<Bool>, _ title: String, nextText: String, _ buttonColor: Color = Color(UIColor.label)) -> some View {
-    return self.modifier(NavigationBarWithTextButtonStyle(isNextClick: isNextClick, isDisalbeNextButton: isDisalbeNextButton, title: title, nextText: nextText, buttonColor: buttonColor))
+  func navigationBarWithTextButtonStyle(isNextClick: Binding<Bool>, isTitleClick: Binding<Bool>, isDisalbeNextButton: Binding<Bool>, isDisalbeTitleButton: Binding<Bool>,_ title: String, nextText: String, _ buttonColor: Color = Color(UIColor.label)) -> some View {
+    return self.modifier(NavigationBarWithTextButtonStyle(isNextClick: isNextClick, isTitleClick: isTitleClick, isDisalbeNextButton: isDisalbeNextButton, isDisalbeTitleButton: isDisalbeTitleButton, title: title, nextText: nextText, buttonColor: buttonColor))
   }
   
   func navigationBarInlineStyle(isNextClick: Binding<Bool>, isDisalbeNextButton: Binding<Bool>, buttonColor: Color = Color(UIColor.label), _ title: String = "") -> some View {

--- a/Sofa/Configuration/ViewModifiers/KeyboardHeightHelper.swift
+++ b/Sofa/Configuration/ViewModifiers/KeyboardHeightHelper.swift
@@ -11,12 +11,22 @@ import Combine
 
 class KeyboardHeightHelper: ObservableObject {
   @Published var keyboardHeight: CGFloat = 0
+  @Published var keyboardWillShowHeight: CGFloat = 0
   
   init(){
     self.listenForKeyboardNotifications()
   }
   
   private func listenForKeyboardNotifications() {
+    NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification,
+                                           object: nil,
+                                           queue: .main) { (notification) in
+      guard let userInfo = notification.userInfo,
+            let keyboardRect = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+      
+      self.keyboardWillShowHeight = keyboardRect.height
+    }
+    
     NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification,
                                            object: nil,
                                            queue: .main) { (notification) in

--- a/Sofa/Configuration/ViewModifiers/KeyboardHeightHelper.swift
+++ b/Sofa/Configuration/ViewModifiers/KeyboardHeightHelper.swift
@@ -40,6 +40,7 @@ class KeyboardHeightHelper: ObservableObject {
                                            object: nil,
                                            queue: .main) { (notification) in
       self.keyboardHeight = 0
+      self.keyboardWillShowHeight = 0
     }
   }
 }

--- a/Sofa/Configuration/ViewModifiers/NavigationBarWithTextButtonStyle.swift
+++ b/Sofa/Configuration/ViewModifiers/NavigationBarWithTextButtonStyle.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct NavigationBarWithTextButtonStyle: ViewModifier {
   @Environment(\.presentationMode) var presentable
   @Binding var isNextClick: Bool
+  @Binding var isTitleClick: Bool
   @Binding var isDisalbeNextButton: Bool
+  @Binding var isDisalbeTitleButton: Bool
   var title: String = ""
   var nextText: String = ""
   var buttonColor: Color
@@ -24,6 +26,7 @@ struct NavigationBarWithTextButtonStyle: ViewModifier {
           HStack(spacing: 0) {
             Image(systemName: "chevron.left")
             Text("이전")
+              .font(.custom("Pretendard-Medium", size: 16))
           }
         })
         .accentColor(buttonColor)
@@ -33,6 +36,7 @@ struct NavigationBarWithTextButtonStyle: ViewModifier {
         }, label: {
           HStack(spacing: 0) {
             Text(nextText)
+              .font(.custom("Pretendard-Medium", size: 16))
           }
         })
         .disabled(isDisalbeNextButton)
@@ -40,7 +44,21 @@ struct NavigationBarWithTextButtonStyle: ViewModifier {
         .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
       )
       .navigationBarTitleDisplayMode(.inline)
-      .navigationTitle(title)
+      .toolbar {
+        ToolbarItem(placement: .principal) {
+          VStack {
+            Button(action: {
+              isTitleClick = true
+            }) {
+              Text(title)
+                .font(.custom("Pretendard-Medium", size: 16))
+                .foregroundColor(Color.black)
+                .bold()
+            }
+            .disabled(isDisalbeTitleButton)
+          }
+        }
+      }
       .onAppear {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
@@ -57,7 +75,7 @@ struct NavigationBarWithTextButtonStyle_Previews: PreviewProvider {
   static var previews: some View {
     NavigationView {
       Color.gray.edgesIgnoringSafeArea(.all)
-        .navigationBarWithTextButtonStyle(isNextClick: .constant(true), isDisalbeNextButton: .constant(false), "제목", nextText: "올리기", Color.init(hex: "#43A047"))
+        .navigationBarWithTextButtonStyle(isNextClick: .constant(true), isTitleClick: .constant(true), isDisalbeNextButton: .constant(false), isDisalbeTitleButton: .constant(false), "제목", nextText: "올리기", Color.init(hex: "#43A047"))
     }
   }
 }

--- a/Sofa/Configuration/ViewModifiers/ToastMessage.swift
+++ b/Sofa/Configuration/ViewModifiers/ToastMessage.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ToastMessage: ViewModifier {
   @Binding var data: MessageData
   @Binding var isShow: Bool
+  let topInset: CGFloat
   
   struct MessageData {
     var title: String
@@ -19,7 +20,7 @@ struct ToastMessage: ViewModifier {
   enum MessageType {
     case Registration // 즐겨찾기, 다운로드, 대표 사진
     case Warning      // 사진 선택
-    case Remove       // 사진 제거
+    case Remove       // 사진 제거, 글자 제한
     
     var iconColor: Color {
       switch self {
@@ -50,7 +51,7 @@ struct ToastMessage: ViewModifier {
           .cornerRadius(80)
           Spacer()
         }
-        .padding(.top, 11)
+        .padding(.top, 11 + topInset)
         .animation(.easeInOut) // 점점 빨라졌다 끝에가서 다시 느려지는 옵션
         .transition(AnyTransition.move(edge: .top).combined(with: .opacity))
         .onTapGesture {
@@ -70,8 +71,8 @@ struct ToastMessage: ViewModifier {
 }
 
 extension View {
-  func toastMessage(data: Binding<ToastMessage.MessageData>, isShow: Binding<Bool>) -> some View {
-    self.modifier(ToastMessage(data: data, isShow: isShow))
+  func toastMessage(data: Binding<ToastMessage.MessageData>, isShow: Binding<Bool>, topInset: CGFloat) -> some View {
+    self.modifier(ToastMessage(data: data, isShow: isShow, topInset: topInset))
   }
 }
 
@@ -81,6 +82,6 @@ struct toastMessage_Previews: PreviewProvider {
     
     Color.gray
       .edgesIgnoringSafeArea(.all)
-      .toastMessage(data: .constant(messageData), isShow: .constant(true))
+      .toastMessage(data: .constant(messageData), isShow: .constant(true), topInset: 0)
   }
 }

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -68,8 +68,8 @@ struct AlbumDetailView: View {
           // 댓글 click
           NavigationLink("", destination: AlbumImageDetailView(isPreCommentClick: true, image: selectImage, index: selectImageIndex), isActive: $isCommentClick)
         }
-        .toastMessage(data: $messageData, isShow: $isBookmarkClick)
-        .toastMessage(data: $messageData2, isShow: $isToastMessage)
+        .toastMessage(data: $messageData, isShow: $isBookmarkClick, topInset: 0)
+        .toastMessage(data: $messageData2, isShow: $isToastMessage, topInset: 0)
         .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isTitleClick: $isTitleClick, isDisalbeNextButton: .constant(false), isDisalbeTitleButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
         .fullScreenCover(isPresented: $isUpdateDate) {
           AlbumSelectDateView(title: "날짜 수정", isCameraCancle: .constant(false))

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct AlbumDetailView: View {
+  @State var isTitleClick = false
   @State var isEdit = false
   
   // 이미지
@@ -69,7 +70,7 @@ struct AlbumDetailView: View {
         }
         .toastMessage(data: $messageData, isShow: $isBookmarkClick)
         .toastMessage(data: $messageData2, isShow: $isToastMessage)
-        .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isDisalbeNextButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
+        .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isTitleClick: $isTitleClick, isDisalbeNextButton: .constant(false), isDisalbeTitleButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
         .fullScreenCover(isPresented: $isUpdateDate) {
           AlbumSelectDateView(title: "날짜 수정", isCameraCancle: .constant(false))
         }

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -74,13 +74,17 @@ struct AlbumDetailView: View {
         .fullScreenCover(isPresented: $isUpdateDate) {
           AlbumSelectDateView(title: "날짜 수정", isCameraCancle: .constant(false))
         }
+        .fullScreenCover(isPresented: $isTitleClick) {
+          AlbumTitleEditView(title: info.title, isShowing: $isTitleClick)
+            .background(BackgroundCleanerView())
+        }
         .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
       }
       .navigationViewStyle(StackNavigationViewStyle())
       .navigationBarHidden(true)
       .onAppear { UITabBar.hideTabBar() }
       
-      if isEllipsisClick { // action sheet
+      if isEllipsisClick || isTitleClick { // action sheet
         Color.black
           .opacity(0.7)
           .ignoresSafeArea()
@@ -88,7 +92,9 @@ struct AlbumDetailView: View {
             isEllipsisClick = false
           }
         
-        actionSheetView // 바텀 Sheet
+        if isEllipsisClick {
+          actionSheetView // 바텀 Sheet
+        }
       }
     }
   }

--- a/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
@@ -42,54 +42,57 @@ struct AlbumImageDetailView: View {
         }
       ]
     )
+    
   }
   
   var body: some View {
-    ZStack {
-      Button(action: {
-        touchImage.toggle()
-      }) {
-        Image(uiImage: image)
-          .resizable()
-          .scaledToFit()
-          .pinchToZoom()
-      }
-      
-      Color.clear
-        .ignoresSafeArea()
-        .overlay(
-          AlbumImageDetailNavigationBar(safeTop: Screen.safeAreaTop)
-            .opacity(touchImage ? 0 : 1) // show/hidden toggle 기능
-        )
-        .overlay(
-          AlbumImageDetailSettingBar(isCommentClick: $isCommentClick, isEllipsisClick: $isEllipsisClick, info: MockData().albumDetail.elements[0]) // 임시
-            .opacity(touchImage ? 0 : 1) // show/hidden toggle 기능
-        )
-      
-      if isCommentClick || isEllipsisClick { // 댓글 or action sheet
-        Color.black
-          .opacity(0.7)
-          .ignoresSafeArea()
-          .onTapGesture {
-            isEllipsisClick = false
-          }
+    GeometryReader { geometry in
+      ZStack {
+        Button(action: {
+          touchImage.toggle()
+        }) {
+          Image(uiImage: image)
+            .resizable()
+            .scaledToFit()
+            .pinchToZoom()
+        }
         
-        if isEllipsisClick {
-          actionSheetView // 바텀 Sheet
+        Color.clear
+          .ignoresSafeArea()
+          .overlay(
+            AlbumImageDetailNavigationBar(safeTop: geometry.safeAreaInsets.top)
+              .opacity(touchImage ? 0 : 1) // show/hidden toggle 기능
+          )
+          .overlay(
+            AlbumImageDetailSettingBar(isCommentClick: $isCommentClick, isEllipsisClick: $isEllipsisClick, info: MockData().albumDetail.elements[0]) // 임시
+              .opacity(touchImage ? 0 : 1) // show/hidden toggle 기능
+          )
+        
+        if isCommentClick || isEllipsisClick { // 댓글 or action sheet
+          Color.black
+            .opacity(0.7)
+            .ignoresSafeArea()
+            .onTapGesture {
+              isEllipsisClick = false
+            }
+          
+          if isEllipsisClick {
+            actionSheetView // 바텀 Sheet
+          }
         }
       }
-    }
-    .background(Color.black)
-    .ignoresSafeArea()
-    .navigationBarHidden(true) // 이전 Navigation bar 무시
-    .toastMessage(data: $messageData, isShow: $isDownloadClick)
-    .fullScreenCover(isPresented: $isCommentClick) {
-      AlbumCommentView(isShowing: $isCommentClick)
-        .background(BackgroundCleanerView())
-    }
-    .onAppear {
-      if isPreCommentClick { // Detail View에서 댓글 버튼을 눌렀을때
-        isCommentClick = true
+      .background(Color.black)
+      .ignoresSafeArea()
+      .navigationBarHidden(true) // 이전 Navigation bar 무시
+      .toastMessage(data: $messageData, isShow: $isDownloadClick)
+      .fullScreenCover(isPresented: $isCommentClick) {
+        AlbumCommentView(isShowing: $isCommentClick)
+          .background(BackgroundCleanerView())
+      }
+      .onAppear {
+        if isPreCommentClick { // Detail View에서 댓글 버튼을 눌렀을때
+          isCommentClick = true
+        }
       }
     }
   }

--- a/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
@@ -52,7 +52,6 @@ struct AlbumImageDetailView: View {
         Image(uiImage: image)
           .resizable()
           .scaledToFit()
-        //              .frame(width: Screen.maxWidth, height: Screen.maxHeight) // 임시
           .pinchToZoom()
       }
       

--- a/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
@@ -84,7 +84,7 @@ struct AlbumImageDetailView: View {
       .background(Color.black)
       .ignoresSafeArea()
       .navigationBarHidden(true) // 이전 Navigation bar 무시
-      .toastMessage(data: $messageData, isShow: $isDownloadClick)
+      .toastMessage(data: $messageData, isShow: $isDownloadClick, topInset: 0)
       .fullScreenCover(isPresented: $isCommentClick) {
         AlbumCommentView(isShowing: $isCommentClick)
           .background(BackgroundCleanerView())

--- a/Sofa/Sources/View/Album/AlbumPhotoAddView/AlbumPhotoAddView.swift
+++ b/Sofa/Sources/View/Album/AlbumPhotoAddView/AlbumPhotoAddView.swift
@@ -43,7 +43,7 @@ struct AlbumPhotoAddView: View {
       }
       .background(Color.black) // 배경색
       .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
-      .toastMessage(data: $messageData, isShow: $showToastMessage)
+      .toastMessage(data: $messageData, isShow: $showToastMessage, topInset: 0)
       .navigationBarInlineStyle(isNextClick: $isNext, isDisalbeNextButton: .constant(selected.isEmpty), buttonColor: Color.init(hex: "#43A047"), "사진 선택") // 임시 컬러
       .onDisappear { UITabBar.showTabBar() }
     }

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
@@ -1,0 +1,20 @@
+//
+//  AlbumTitleEditView.swift
+//  Sofa
+//
+//  Created by geonhyeong on 2022/07/15.
+//
+
+import SwiftUI
+
+struct AlbumTitleEditView: View {
+  var body: some View {
+    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  }
+}
+
+struct AlbumTitleEditView_Previews: PreviewProvider {
+  static var previews: some View {
+    AlbumTitleEditView()
+  }
+}

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
@@ -15,6 +15,8 @@ struct AlbumTitleEditView: View {
   @Binding var isShowing: Bool
   let duration = 0.5
   
+  let textLimit: Int = 20
+
   var completeButton: some View {
     VStack {
       Button(action: {
@@ -53,7 +55,7 @@ struct AlbumTitleEditView: View {
         }
         
         if isTextView { // 0.5초 후 Show
-          AlbumTitleEditNavigationBar(title: $title, safeTop: geometry.safeAreaInsets.top)
+          AlbumTitleEditNavigationBar(title: $title, isLimite: $isLimite, safeTop: geometry.safeAreaInsets.top, textLimit: textLimit)
             .transition(.move(edge: .top))
             .animation(.easeInOut(duration: duration/2))
           

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
@@ -12,9 +12,10 @@ struct AlbumTitleEditView: View {
   @StateObject var keyboardHeightHelper = KeyboardHeightHelper()
   @State var title: String
   @State var isTextView = false
+  @State var isLimite = false
+  @State var messageData: ToastMessage.MessageData = ToastMessage.MessageData(title: "글자는 20자까지 입력가능합니다", type: .Remove)
   @Binding var isShowing: Bool
   let duration = 0.5
-  
   let textLimit: Int = 20
 
   var completeButton: some View {
@@ -64,6 +65,7 @@ struct AlbumTitleEditView: View {
             .animation(.easeInOut(duration: duration/2))
         }
       }
+      .toastMessage(data: $messageData, isShow: $isLimite, topInset: Screen.safeAreaTop + 65)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
       .ignoresSafeArea()
       .onAppear {

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
@@ -6,32 +6,82 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct AlbumTitleEditView: View {
   @StateObject var keyboardHeightHelper = KeyboardHeightHelper()
+  @State var title: String
+  @State var isTextView = false
+  @Binding var isShowing: Bool
   let duration = 0.5
+  
+  var completeButton: some View {
+    VStack {
+      Button(action: {
+        self.isTextView = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+          // isTextView가 닫히고
+          self.isShowing = false
+        }
+      }) {
+        Text("완료")
+          .foregroundColor(Color.white)
+          .font(.custom("Pretendard-Bold", size: 18))
+          .frame(maxWidth: .infinity, minHeight: 48)
+          .background(Color(hex: title.isEmpty ? "#A8A8A8" : "#43A047")) // 임시
+          .clipShape(RoundedRectangle(cornerRadius: 6))
+          .padding(.top, 8)
+      }
+      .disabled(title.isEmpty)
+      Spacer()
+    }
+    .padding(.horizontal, 16)
+    .frame(width: Screen.maxWidth, height: 64)
+    .background(Color.white)
     .offset(y: -keyboardHeightHelper.keyboardWillShowHeight)
+  }
+  
   var body: some View {
-    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    GeometryReader { geometry in
+      ZStack(alignment: .bottom) {
+        ModalBackGround { // Back Ground
+          self.isTextView = false
           DispatchQueue.main.asyncAfter(deadline: .now() + duration/2) {
             // isTextView가 닫히고
             self.isShowing = false
           }
+        }
+        
+        if isTextView { // 0.5초 후 Show
+          AlbumTitleEditNavigationBar(title: $title, safeTop: geometry.safeAreaInsets.top)
             .transition(.move(edge: .top))
             .animation(.easeInOut(duration: duration/2))
+          
+          completeButton
             .transition(.move(edge: .bottom))
             .animation(.easeInOut(duration: duration/2))
+        }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+      .ignoresSafeArea()
       .onAppear {
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
           // 0.5초 후 isTextView Show
           self.isTextView = true
         }
       }
+    }
   }
 }
 
 struct AlbumTitleEditView_Previews: PreviewProvider {
   static var previews: some View {
-    AlbumTitleEditView()
+    ZStack {
+      Color.black
+        .opacity(0.7)
+        .ignoresSafeArea()
+      
+      AlbumTitleEditView(title: "2022-07-13 앨범", isShowing: .constant(true))
+    }
   }
 }

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/AlbumTitleEditView.swift
@@ -8,8 +8,25 @@
 import SwiftUI
 
 struct AlbumTitleEditView: View {
+  @StateObject var keyboardHeightHelper = KeyboardHeightHelper()
+  let duration = 0.5
+    .offset(y: -keyboardHeightHelper.keyboardWillShowHeight)
   var body: some View {
     Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+          DispatchQueue.main.asyncAfter(deadline: .now() + duration/2) {
+            // isTextView가 닫히고
+            self.isShowing = false
+          }
+            .transition(.move(edge: .top))
+            .animation(.easeInOut(duration: duration/2))
+            .transition(.move(edge: .bottom))
+            .animation(.easeInOut(duration: duration/2))
+      .onAppear {
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+          // 0.5초 후 isTextView Show
+          self.isTextView = true
+        }
+      }
   }
 }
 

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
@@ -13,6 +13,14 @@ struct AlbumTitleEditNavigationBar: View {
   @Binding var title: String
   let paddingValue: CGFloat = 12
   let safeTop: CGFloat
+  let textLimit: Int
+  
+  // 텍스트 길이를 제한하는 기능
+  func limitText(_ upper: Int) {
+    if title.count > upper {
+      title = String(title.prefix(upper))
+    }
+  }
   
   var body: some View {
     VStack {
@@ -27,6 +35,7 @@ struct AlbumTitleEditNavigationBar: View {
             .background(Color.white) // 입력 Area 색상
             .cornerRadius(6)
             .highlightTextField(firstLineWidth: 1, secondLineWidth: 4)
+            .onReceive(Just(title)) { _ in limitText(textLimit) }
           
           // 아이콘 X
           HStack{
@@ -53,6 +62,6 @@ struct AlbumTitleEditNavigationBar: View {
 
 struct AlbumTitleEditNavigationBar_Previews: PreviewProvider {
   static var previews: some View {
-    AlbumTitleEditNavigationBar(title: .constant(""), safeTop: 10)
+    AlbumTitleEditNavigationBar(title: .constant(""), isLimite: .constant(false), safeTop: 10, textLimit: 20)
   }
 }

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
@@ -11,6 +11,7 @@ import Combine
 struct AlbumTitleEditNavigationBar: View {
   @State var firstResponder: FirstResponders? = Sofa.FirstResponders.text
   @Binding var title: String
+  @Binding var isLimite: Bool
   let paddingValue: CGFloat = 12
   let safeTop: CGFloat
   let textLimit: Int
@@ -19,6 +20,7 @@ struct AlbumTitleEditNavigationBar: View {
   func limitText(_ upper: Int) {
     if title.count > upper {
       title = String(title.prefix(upper))
+      isLimite = true
     }
   }
   

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 struct AlbumTitleEditNavigationBar: View {
   @State var firstResponder: FirstResponders? = Sofa.FirstResponders.text
@@ -17,14 +18,29 @@ struct AlbumTitleEditNavigationBar: View {
     VStack {
       VStack {
         Spacer()
-        TextField("앨범 제목", text: $title)
-          .firstResponder(id: FirstResponders.text, firstResponder: $firstResponder, resignableUserOperations: .none)
-          .font(.custom("Pretendard-Medium", size: 18))
-          .customTextField(padding: paddingValue)
-          .disableAutocorrection(true)
-          .background(Color.white) // 입력 Area 색상
-          .cornerRadius(6)
-          .highlightTextField(firstLineWidth: 1, secondLineWidth: 4)
+        ZStack {
+          TextField("앨범 제목", text: $title)
+            .firstResponder(id: FirstResponders.text, firstResponder: $firstResponder, resignableUserOperations: .none)
+            .font(.custom("Pretendard-Medium", size: 18))
+            .customTextField(padding: paddingValue)
+            .disableAutocorrection(true)
+            .background(Color.white) // 입력 Area 색상
+            .cornerRadius(6)
+            .highlightTextField(firstLineWidth: 1, secondLineWidth: 4)
+          
+          // 아이콘 X
+          HStack{
+            Spacer()
+            Image(systemName: "xmark")
+              .font(.system(size: 20))
+              .foregroundColor(Color.black.opacity(!title.isEmpty ? 0.4 : 0))
+              .padding(.trailing, 13.5)
+              .contentShape(Rectangle())
+              .onTapGesture {
+                title = ""
+              }
+          }
+        }
       }
       .frame(height: safeTop + 10 + paddingValue)
       .frame(maxWidth: .infinity, alignment: .center)

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
@@ -1,0 +1,20 @@
+//
+//  AlbumTitleEditNavigationBar.swift
+//  Sofa
+//
+//  Created by geonhyeong on 2022/07/15.
+//
+
+import SwiftUI
+
+struct AlbumTitleEditNavigationBar: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct AlbumTitleEditNavigationBar_Previews: PreviewProvider {
+    static var previews: some View {
+        AlbumTitleEditNavigationBar()
+    }
+}

--- a/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
+++ b/Sofa/Sources/View/Album/AlbumTitleEditView/SubViews/NavigationBar/AlbumTitleEditNavigationBar.swift
@@ -8,13 +8,35 @@
 import SwiftUI
 
 struct AlbumTitleEditNavigationBar: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  @State var firstResponder: FirstResponders? = Sofa.FirstResponders.text
+  @Binding var title: String
+  let paddingValue: CGFloat = 12
+  let safeTop: CGFloat
+  
+  var body: some View {
+    VStack {
+      VStack {
+        Spacer()
+        TextField("앨범 제목", text: $title)
+          .firstResponder(id: FirstResponders.text, firstResponder: $firstResponder, resignableUserOperations: .none)
+          .font(.custom("Pretendard-Medium", size: 18))
+          .customTextField(padding: paddingValue)
+          .disableAutocorrection(true)
+          .background(Color.white) // 입력 Area 색상
+          .cornerRadius(6)
+          .highlightTextField(firstLineWidth: 1, secondLineWidth: 4)
+      }
+      .frame(height: safeTop + 10 + paddingValue)
+      .frame(maxWidth: .infinity, alignment: .center)
+      .padding(EdgeInsets(top: 20 + paddingValue, leading: 16, bottom: 15, trailing: 16))
+      .background(Color.white.ignoresSafeArea(edges: .top))
+      Spacer()
     }
+  }
 }
 
 struct AlbumTitleEditNavigationBar_Previews: PreviewProvider {
-    static var previews: some View {
-        AlbumTitleEditNavigationBar()
-    }
+  static var previews: some View {
+    AlbumTitleEditNavigationBar(title: .constant(""), safeTop: 10)
+  }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- Navigation tab action
- 제목 수정 UI
- keyBoard 
- Toast 알림

🌱 PR 포인트
- `navigationBarWithTextButtonStyle`의 Parameter가 `isTitleClick: Binding<Bool>`, `isDisalbeTitleButton: Binding<Bool>` 2개 추가 되었습니다.
- Naviagaion에 title의 **click event를 만들려면**, `toolbar`를 통해 `Button`을 만들어야합니다.
- 유진님이 만들어주신 `KeyboardHeightHelper`에 `keyboardWillShowHeight` Property를 추가해 사용하게 되었습니다.
- ToastMessage를 넣을때, NaviagionView안에 
- NavigationView에서 부르지 않을때를 고려해서, `ToastMessage`의 Parameter가 `topInset`이 추가 되었습니다.
- AlbumTitleEditView.swift에 keyboard 나오는 속도를 고려해서 animation duration을 계산했습니다.
- **TextField 구현할때**, 주민님의 `customTextField`과 유진님의 `firstResponder`를 사용하게 되었습니다.

## 📸 스크린샷
|![show:hidden](https://user-images.githubusercontent.com/48436020/179343621-6ea8044c-f1c9-446c-b198-cbc0a82fcac0.gif)|![enable](https://user-images.githubusercontent.com/48436020/179343625-dc6db47a-2e6d-4bbf-91af-9f410a0b627b.gif)|![limit](https://user-images.githubusercontent.com/48436020/179343630-131f2532-e14f-45bb-8457-4e1a43bc8655.gif)|
|:--:|:--:|:--:|
|hidden|enable|limit|

## ⭐️ 난이도 
- ⭐️⭐️⭐️⭐️ (keyboard, firstResponder와 animation 😭)

## 📮 관련 이슈
- Resolved: #92 
