### PR TITLE
[FEAT] 앨범 및 게시물 날짜 수정 & 업로드시, 날짜 선택

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		C4667A4C284B6FF400A4A759 /* SofaUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4667A4B284B6FF400A4A759 /* SofaUITestsLaunchTests.swift */; };
 		C46C56CE2881B40700677E63 /* AlbumTitleEditNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46C56CD2881B40600677E63 /* AlbumTitleEditNavigationBar.swift */; };
 		C46C56D32882BD6600677E63 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46C56D22882BD6600677E63 /* APIConstants.swift */; };
+		C46C56D62882EAC500677E63 /* AlbumEditDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46C56D52882EAC500677E63 /* AlbumEditDateView.swift */; };
 		C481B6B72875D4E7005D6831 /* AlbumImageDetailNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481B6B62875D4E7005D6831 /* AlbumImageDetailNavigationBar.swift */; };
 		C481B6BC2875FD0A005D6831 /* Blur.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481B6BB2875FD0A005D6831 /* Blur.swift */; };
 		C481B6C1287607DB005D6831 /* AlbumImageDetailSettingBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C481B6C0287607DB005D6831 /* AlbumImageDetailSettingBar.swift */; };
@@ -269,6 +270,7 @@
 		C4667A4B284B6FF400A4A759 /* SofaUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SofaUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		C46C56CD2881B40600677E63 /* AlbumTitleEditNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumTitleEditNavigationBar.swift; sourceTree = "<group>"; };
 		C46C56D22882BD6600677E63 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		C46C56D52882EAC500677E63 /* AlbumEditDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumEditDateView.swift; sourceTree = "<group>"; };
 		C481B6B62875D4E7005D6831 /* AlbumImageDetailNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImageDetailNavigationBar.swift; sourceTree = "<group>"; };
 		C481B6BB2875FD0A005D6831 /* Blur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blur.swift; sourceTree = "<group>"; };
 		C481B6C0287607DB005D6831 /* AlbumImageDetailSettingBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImageDetailSettingBar.swift; sourceTree = "<group>"; };
@@ -479,6 +481,7 @@
 				C4B8F2BD2852908E0000B8CB /* AlbumPhotoAddView */,
 				C495F60228571F51009B3BDE /* AlbumRecordAddView */,
 				C495F5F42855DA1A009B3BDE /* AlbumSelectDateView */,
+				C46C56D42882EA9D00677E63 /* AlbumEditDateView */,
 			);
 			path = Album;
 			sourceTree = "<group>";
@@ -742,6 +745,14 @@
 				6F6E5A542882B26A00C0734E /* APIConstants.swift */,
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		C46C56D42882EA9D00677E63 /* AlbumEditDateView */ = {
+			isa = PBXGroup;
+			children = (
+				C46C56D52882EAC500677E63 /* AlbumEditDateView.swift */,
+			);
+			path = AlbumEditDateView;
 			sourceTree = "<group>";
 		};
 		C481B6B42875D4BA005D6831 /* SubViews */ = {
@@ -1315,6 +1326,7 @@
 				C4EC31CB284F8CBB0049F2C4 /* Album.swift in Sources */,
 				0AAB367F286381C000A47B24 /* HomeInfo.swift in Sources */,
 				6F22E53C284B9D5A0069D268 /* Base.swift in Sources */,
+				C46C56D62882EAC500677E63 /* AlbumEditDateView.swift in Sources */,
 				C495F5F72855DAB3009B3BDE /* AlbumSelectDateView.swift in Sources */,
 				C495F61F285BC2C8009B3BDE /* AudioBarView.swift in Sources */,
 				C495F5F12855C3AA009B3BDE /* AlbumTypeRow.swift in Sources */,

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -27,7 +27,7 @@ struct AlbumDetailView: View {
   @State var isToastMessage: Bool = false
   @State var messageData2: ToastMessage.MessageData = ToastMessage.MessageData(title: "다운로드 완료", type: .Registration)
 
-  @State var isUpdateDate: Bool = false  // 날짜 수정
+  @State var isUpdateDate: Bool = false  // 사진 & 녹음 날짜 수정
   let info = MockData().albumDetail
   
   var actionSheetView: some View {
@@ -71,8 +71,11 @@ struct AlbumDetailView: View {
         .toastMessage(data: $messageData, isShow: $isBookmarkClick, topInset: 0)
         .toastMessage(data: $messageData2, isShow: $isToastMessage, topInset: 0)
         .navigationBarWithTextButtonStyle(isNextClick: $isEdit, isTitleClick: $isTitleClick, isDisalbeNextButton: .constant(false), isDisalbeTitleButton: .constant(false), info.title, nextText: "편집", Color.init(hex: "#43A047"))
-        .fullScreenCover(isPresented: $isUpdateDate) {
-          AlbumSelectDateView(title: "날짜 수정", isCameraCancle: .constant(false))
+        .fullScreenCover(isPresented: $isEdit) { // 앨범 날짜 수정
+          AlbumEditDateView(albumId: "0") // 임시
+        }
+        .fullScreenCover(isPresented: $isUpdateDate) { // 사진 & 녹음 수정
+          AlbumEditDateView(photoId: "0") // 임시
         }
         .fullScreenCover(isPresented: $isTitleClick) {
           AlbumTitleEditView(title: info.title, isShowing: $isTitleClick)

--- a/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
@@ -8,8 +8,78 @@
 import SwiftUI
 
 struct AlbumEditDateView: View {
+  @Environment(\.presentationMode) var presentable
+  @State var isNext = false
+  @State var isDisalbeNextButton: Bool = false
+  @State var showDatePicker: Bool = true
+  @State var enableToggle: Bool = false
+  @State var currentDate: Date = Date()
+  let buttonColor: Color = Color.init(hex: "#43A047") // 임시
+  var albumId: String?   // 앨범 날짜 수정
+  var photoId: String?   // 사진 날짜 수정
+  var recordId: String?  // 녹음 날짜 수정
+
   var body: some View {
-    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    NavigationView {
+      VStack(spacing: 0) {
+        Divider()
+        Spacer() // 임시 - 여백용
+          .frame(height: 8)
+        Group {
+          GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: $enableToggle, currentDate: $currentDate)
+        }
+        .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
+        .background(Color.white)
+        Spacer()
+      }
+      .background(Color.init(hex: "#FAF8F0")) // 임시
+      .navigationBarItems(
+        leading: Button(action: {
+          presentable.wrappedValue.dismiss()
+        }, label: {
+          HStack(spacing: 0) {
+            Text("취소")
+              .font(.custom("Pretendard-Medium", size: 16))
+              .fontWeight(.semibold)
+          }
+        })
+        .accentColor(buttonColor)
+        .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)),
+        trailing: Button(action: {
+          if albumId != nil {         // 앨범
+            print("앨범 날짜 수정")
+          } else if photoId != nil {  // 사진
+            print("사진 날짜 수정")
+          } else if recordId != nil { // 녹음
+            print("녹음 날짜 수정")
+          }
+          presentable.wrappedValue.dismiss()
+        }, label: {
+          HStack(spacing: 0) {
+            Text("수정")
+              .font(.custom("Pretendard-Medium", size: 16))
+              .fontWeight(.semibold)
+          }
+        })
+        .disabled(isDisalbeNextButton)
+        .accentColor(buttonColor)
+        .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+      )
+      .navigationBarTitleDisplayMode(.inline)
+      .navigationTitle("날짜 수정")
+      .onAppear {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor =
+        UIColor.systemBackground.withAlphaComponent(1)
+        UINavigationBar.appearance().standardAppearance = appearance
+        UINavigationBar.appearance().compactAppearance = appearance
+        UINavigationBar.appearance().scrollEdgeAppearance = appearance
+      }
+      .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
+    }
+    .navigationViewStyle(StackNavigationViewStyle())
+    .navigationBarHidden(true)
   }
 }
 

--- a/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
@@ -49,6 +49,7 @@ struct AlbumEditDateView: View {
           } else if recordId != nil { // 녹음
             print("녹음 날짜 수정")
           }
+//          print(currentDate.getFormattedDate(format: "yyyy-MM-dd"))
           presentable.wrappedValue.dismiss()
         }, label: {
           HStack(spacing: 0) {

--- a/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct AlbumEditDateView: View {
   @Environment(\.presentationMode) var presentable
-  @State var showDatePicker: Bool = true
-  @State var enableToggle: Bool = false
   @State var currentDate: Date = Date()
   let buttonColor: Color = Color.init(hex: "#43A047") // 임시
   var albumId: String?   // 앨범 날짜 수정
@@ -24,7 +22,7 @@ struct AlbumEditDateView: View {
         Spacer() // 임시 - 여백용
           .frame(height: 8)
         Group {
-          GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: $enableToggle, currentDate: $currentDate)
+          GeneralDatePickerView(showDatePicker: .constant(true), enableToggle: .constant(false), currentDate: $currentDate)
         }
         .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
         .background(Color.white)

--- a/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct AlbumEditDateView: View {
   @Environment(\.presentationMode) var presentable
-  @State var isNext = false
-  @State var isDisalbeNextButton: Bool = false
   @State var showDatePicker: Bool = true
   @State var enableToggle: Bool = false
   @State var currentDate: Date = Date()
@@ -61,7 +59,6 @@ struct AlbumEditDateView: View {
               .fontWeight(.semibold)
           }
         })
-        .disabled(isDisalbeNextButton)
         .accentColor(buttonColor)
         .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
       )

--- a/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumEditDateView/AlbumEditDateView.swift
@@ -1,0 +1,20 @@
+//
+//  AlbumEditDateView.swift
+//  Sofa
+//
+//  Created by geonhyeong on 2022/07/16.
+//
+
+import SwiftUI
+
+struct AlbumEditDateView: View {
+  var body: some View {
+    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  }
+}
+
+struct AlbumEditDateView_Previews: PreviewProvider {
+  static var previews: some View {
+    AlbumEditDateView()
+  }
+}

--- a/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct AlbumSelectDateView: View {
   @Environment(\.presentationMode) var presentable
-  @State var showDatePicker: Bool = true
-  @State var enableToggle: Bool = false
   @State var currentDate: Date = Date()
   
   var title: String = "올리기"
@@ -55,7 +53,7 @@ struct AlbumSelectDateView: View {
         Spacer() // 임시 - 여백용
           .frame(height: 8)
         Group {
-          GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: $enableToggle, currentDate: $currentDate)
+          GeneralDatePickerView(showDatePicker: .constant(true), enableToggle: .constant(false), currentDate: $currentDate)
         }
         .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
         .background(Color.white)

--- a/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
@@ -84,6 +84,7 @@ struct AlbumSelectDateView: View {
           } else { // 카메라
             presentable.wrappedValue.dismiss()
           }
+//          print(currentDate.getFormattedDate(format: "yyyy-MM-dd"))
           UITabBar.showTabBar()
         }, label: {
           HStack(spacing: 0) {

--- a/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
@@ -11,6 +11,9 @@ struct AlbumSelectDateView: View {
   @Environment(\.presentationMode) var presentable
   @State var isNext = false
   @State var isDisalbeNextButton: Bool = false
+  @State var showDatePicker: Bool = true
+  @State var enableToggle: Bool = false
+  @State var currentDate: Date = Date()
   var title: String = "올리기"
   let buttonColor: Color = Color.init(hex: "#43A047") // 임시
   
@@ -49,6 +52,11 @@ struct AlbumSelectDateView: View {
         }
         
         Text("select Date")
+        Group {
+          GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: $enableToggle, currentDate: $currentDate)
+        }
+        .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
+        .background(Color.white)
       }
       .background(Color.init(hex: "#FAF8F0")) // 임시
       .navigationBarItems(

--- a/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct AlbumSelectDateView: View {
   @Environment(\.presentationMode) var presentable
-  @State var isNext = false
-  @State var isDisalbeNextButton: Bool = false
   @State var showDatePicker: Bool = true
   @State var enableToggle: Bool = false
   @State var currentDate: Date = Date()
@@ -96,7 +94,6 @@ struct AlbumSelectDateView: View {
               .fontWeight(.semibold)
           }
         })
-        .disabled(isDisalbeNextButton)
         .accentColor(buttonColor)
         .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
       )

--- a/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
+++ b/Sofa/Sources/View/Album/AlbumSelectDateView/AlbumSelectDateView.swift
@@ -14,6 +14,7 @@ struct AlbumSelectDateView: View {
   @State var showDatePicker: Bool = true
   @State var enableToggle: Bool = false
   @State var currentDate: Date = Date()
+  
   var title: String = "올리기"
   let buttonColor: Color = Color.init(hex: "#43A047") // 임시
   
@@ -32,10 +33,11 @@ struct AlbumSelectDateView: View {
   
   var body: some View {
     NavigationView {
-      VStack(spacing: 8) {
+      VStack(spacing: 0) {
         if recordParent != nil { // 녹음일 경우
           VStack(spacing: 0) {
-            Text("") // 임시 - 여백용
+            Divider()
+            Spacer() // 임시 - 여백용
               .frame(height: 8)
             
             HStack {
@@ -43,20 +45,23 @@ struct AlbumSelectDateView: View {
               TextField("\(fetcher.recordTitle)", text: $recordTitle)
                 .padding(16)
                 .background(Color.init(hex: "#FAF8F0")) // 임시
+                .font(.custom("Pretendard-Medium", size: 18))
+                .cornerRadius(6)
               Spacer()
             }
             .frame(width: Screen.maxWidth, height: 80) // 임시 - 높이
             .background(Color.white)
           }
-          Spacer()
         }
-        
-        Text("select Date")
+        Divider()
+        Spacer() // 임시 - 여백용
+          .frame(height: 8)
         Group {
           GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: $enableToggle, currentDate: $currentDate)
         }
         .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
         .background(Color.white)
+        Spacer()
       }
       .background(Color.init(hex: "#FAF8F0")) // 임시
       .navigationBarItems(
@@ -69,6 +74,8 @@ struct AlbumSelectDateView: View {
           HStack(spacing: 0) {
             Image(systemName: "chevron.left")
             Text("이전")
+              .font(.custom("Pretendard-Medium", size: 16))
+              .fontWeight(.semibold)
           }
         })
         .accentColor(buttonColor)
@@ -85,6 +92,8 @@ struct AlbumSelectDateView: View {
         }, label: {
           HStack(spacing: 0) {
             Text("올리기")
+              .font(.custom("Pretendard-Medium", size: 16))
+              .fontWeight(.semibold)
           }
         })
         .disabled(isDisalbeNextButton)
@@ -102,6 +111,7 @@ struct AlbumSelectDateView: View {
         UINavigationBar.appearance().compactAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
       }
+      .edgesIgnoringSafeArea([.bottom]) // Bottom만 safeArea 무시
     }
     .navigationViewStyle(StackNavigationViewStyle())
     .navigationBarHidden(true)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
 - GeneralDatePickerView UI 사용하여 옮기기
 - 수정 View는 따로 만들기
 - 사진/녹음일떄 case 구분하기
 
🌱 PR 포인트
- 주민님에게 3가지 확인 부탁드립니다.
- [x] 1. GeneralDatePickerView의 아래 경계선 제거 : 날짜 선택 및 수정 UI에서 처리하고 싶습니다.
- [x] 2. enableToggle 변수가 작동을 안합니다 : 날짜 click시 `GeneralCalendar`가 toggle이 됩니다.
- [x] 3. 날짜 선택시, currentDate에 이전 날짜가 들어가게 됩니다.
ex) 7월 16일 선택시, 7월 15일로 찍힙니다.

## 📸 스크린샷
|![image](https://user-images.githubusercontent.com/48436020/179356754-990c5204-d17c-436a-b397-83ad47699d1f.png)|![image](https://user-images.githubusercontent.com/48436020/179356773-68c3f04a-34ff-4f07-a4d2-260cea3e6e63.png)|
|:--:|:--:|
|업로드 사진|업로드 녹음|

## 📮 관련 이슈
- Resolved: #99 
