### PR TITLE
[FEAT] 경계선 삭제

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		6F22E53E284B9D640069D268 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F22E53D284B9D640069D268 /* Constants.swift */; };
 		6F3E3EBC286B1E3900EF7082 /* AppendTaskModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3E3EBB286B1E3900EF7082 /* AppendTaskModalView.swift */; };
 		6F6E5A552882B26A00C0734E /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6E5A542882B26A00C0734E /* APIConstants.swift */; };
+		6F6E5A572882B7FF00C0734E /* ProfileSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6E5A562882B7FF00C0734E /* ProfileSettingView.swift */; };
 		6F7340BA2874184300707AB7 /* GeneralCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7340B92874184300707AB7 /* GeneralCalendar.swift */; };
 		6F7340BC28741A4800707AB7 /* GeneralDatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7340BB28741A4800707AB7 /* GeneralDatePickerView.swift */; };
 		6F7340BF28741F6F00707AB7 /* TaskMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7340BE28741F6F00707AB7 /* TaskMetaData.swift */; };
@@ -234,6 +235,7 @@
 		6F22E53D284B9D640069D268 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		6F3E3EBB286B1E3900EF7082 /* AppendTaskModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendTaskModalView.swift; sourceTree = "<group>"; };
 		6F6E5A542882B26A00C0734E /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		6F6E5A562882B7FF00C0734E /* ProfileSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingView.swift; sourceTree = "<group>"; };
 		6F7340B92874184300707AB7 /* GeneralCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralCalendar.swift; sourceTree = "<group>"; };
 		6F7340BB28741A4800707AB7 /* GeneralDatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralDatePickerView.swift; sourceTree = "<group>"; };
 		6F7340BE28741F6F00707AB7 /* TaskMetaData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskMetaData.swift; sourceTree = "<group>"; };
@@ -411,6 +413,7 @@
 		6F1553332881C8210048CE54 /* SubViews */ = {
 			isa = PBXGroup;
 			children = (
+				6F6E5A562882B7FF00C0734E /* ProfileSettingView.swift */,
 				6F1553342881C83C0048CE54 /* SettingRow.swift */,
 			);
 			path = SubViews;
@@ -1336,6 +1339,7 @@
 				C4B8F2AA2851CAF80000B8CB /* Ex+View.swift in Sources */,
 				6F6E5A552882B26A00C0734E /* APIConstants.swift in Sources */,
 				C495F6012856446A009B3BDE /* AlbumDetailList.swift in Sources */,
+				6F6E5A572882B7FF00C0734E /* ProfileSettingView.swift in Sources */,
 				0A2887F62870A80B000A72F2 /* FamilyList.swift in Sources */,
 				C495F60E285B5B86009B3BDE /* AuthorizationViewModel.swift in Sources */,
 				C495F5FC2856386A009B3BDE /* AlbumDetailRow.swift in Sources */,

--- a/Sofa/Sources/View/Calendar/GeneralDatePickerView.swift
+++ b/Sofa/Sources/View/Calendar/GeneralDatePickerView.swift
@@ -38,9 +38,10 @@ struct GeneralDatePickerView: View {
               self.showDatePicker.toggle()
             }
           }
-      }.padding(.bottom, 12)
+      }
       if showDatePicker {
         GeneralCalendar(currentDate: $currentDate)
+          .padding(.top, 12)
       }
     }
   }

--- a/Sofa/Sources/View/Calendar/SubViews/AppendTaskModalView.swift
+++ b/Sofa/Sources/View/Calendar/SubViews/AppendTaskModalView.swift
@@ -191,10 +191,18 @@ struct AppendTaskModalView: View {
                 GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: .constant(true), currentDate: $currentDate)
                   .padding(.bottom, 12)
                 
+                if showDatePicker {
+                  Rectangle()
+                    .frame(height: 1.0, alignment: .bottom)
+                    .foregroundColor(Color(hex: "EDEADF"))
+                    .padding(.top, 16)
+                }
+                
                 // 시간
                 if !allDayToggle {
                   TaskTimePicker()
                     .padding(.bottom, 27)
+                    .padding(.top, 12)
                 }
                 
               }.padding(EdgeInsets(top: 30, leading: 19.5, bottom: 0, trailing: 16))

--- a/Sofa/Sources/View/Calendar/SubViews/GeneralCalendar.swift
+++ b/Sofa/Sources/View/Calendar/SubViews/GeneralCalendar.swift
@@ -83,11 +83,6 @@ struct GeneralCalendar: View {
         }
       }
       .padding(EdgeInsets(top: 12, leading: 5, bottom: 0, trailing: 5))
-      
-      Rectangle()
-        .frame(height: 1.0, alignment: .bottom)
-        .foregroundColor(Color(hex: "EDEADF"))
-        .padding(.top, 22)
     
       .onChange(of: currentMonth) { newValue in
         currentDate = getCurrentMonth()

--- a/Sofa/Sources/View/Calendar/SubViews/TaskDetailView.swift
+++ b/Sofa/Sources/View/Calendar/SubViews/TaskDetailView.swift
@@ -123,10 +123,18 @@ struct TaskDetailView: View {
                 GeneralDatePickerView(showDatePicker: $showDatePicker, enableToggle: .constant(true), currentDate: $currentDate)
                   .padding(.bottom, 12)
                 
+                if showDatePicker {
+                  Rectangle()
+                    .frame(height: 1.0, alignment: .bottom)
+                    .foregroundColor(Color(hex: "EDEADF"))
+                    .padding(.top, 16)
+                }
+                
                 // 시간
                 if !allDayToggle {
                   TaskTimePicker()
                     .padding(.bottom, 27)
+                    .padding(.top, 12)
                 }
               }.padding(EdgeInsets(top: 27, leading: 19.5, bottom: 0, trailing: 16))
               

--- a/Sofa/Sources/View/Settings/SubViews/ProfileSettingView.swift
+++ b/Sofa/Sources/View/Settings/SubViews/ProfileSettingView.swift
@@ -1,0 +1,44 @@
+//
+//  ProfileSettingView.swift
+//  Sofa
+//
+//  Created by 임주민 on 2022/07/16.
+//
+
+import SwiftUI
+
+struct ProfileSettingView: View {
+    var body: some View {
+      NavigationView {
+        ZStack{
+          //기본 배경
+          
+          VStack{
+            //사진
+            
+            Spacer()
+          }
+          VStack{
+            //초록 배경
+            
+            //흰 배경
+            
+            //입력창 - 별명
+            
+            //입력창 - 성함
+            
+            //입력창 - 역할
+            
+            //입력창 - 생년월일
+            
+          }
+        }
+      }
+    }
+}
+
+struct ProfileSettingView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileSettingView()
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 앨범뷰와 캘린더에서 나타나는 달력 하단의 경계선이 다른 문제로, 각 뷰에서 추가하기로 하고 공용으로 쓰는 GeneralDatePicker뷰에서는 삭제하기로 했습니다.

🌱 PR 포인트
- 선 삭제 후, AppendTask뷰와 TaskDetail뷰에서 선을 각각 추가해주었습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|<img src="https://user-images.githubusercontent.com/76610340/179357645-2cbe8d3b-1f54-40ea-8f95-f93bf2a3a6e1.png" width="212">|

## 📮 관련 이슈
- Resolved: #103 
