### PR TITLE
[FEAT] 녹음 재생/정지

### DIFF
--- a/Sofa/Sources/View/Album/AlbumRecordAddView/AlbumRecordAddView.swift
+++ b/Sofa/Sources/View/Album/AlbumRecordAddView/AlbumRecordAddView.swift
@@ -37,11 +37,29 @@ struct AlbumRecordAddView: View {
     .frame(width: Screen.maxWidth, height: Screen.maxHeight)
   }
   
+  // 녹음 재생 버튼
+  var playButton: some View {
+    Button(action: {
+      
+    }) {
+      ZStack {
+        Circle()
+          .frame(width: 64, height: 64)
+          .foregroundColor(Color.white)
+        
+        Image(systemName: "play.fill")
+          .resizable()
+          .frame(width: 32, height: 32)
+          .foregroundColor(Color(hex: "D81B60"))
+      }
+    }
+  }
+  
   var recordButtonArea: some View {
     VStack {
       Spacer()
       VStack {
-        HStack {
+        HStack(spacing: 24) {
           Button(action: {
             if self.audioRecorder.isRecording{
               self.audioRecorder.stopRecording()
@@ -72,6 +90,9 @@ struct AlbumRecordAddView: View {
               }
             }
           })
+          if record {
+            playButton // 재생 버튼
+          }
         }
         .padding(.top, 16)
         Spacer()

--- a/Sofa/Sources/View/Album/AlbumRecordAddView/AlbumRecordAddView.swift
+++ b/Sofa/Sources/View/Album/AlbumRecordAddView/AlbumRecordAddView.swift
@@ -40,7 +40,7 @@ struct AlbumRecordAddView: View {
   // 녹음 재생 버튼
   var playButton: some View {
     Button(action: {
-      
+      self.audioRecorder.startPlayback()
     }) {
       ZStack {
         Circle()
@@ -52,6 +52,21 @@ struct AlbumRecordAddView: View {
           .frame(width: 32, height: 32)
           .foregroundColor(Color(hex: "D81B60"))
       }
+    }
+  }
+  
+  // 정지 버튼
+  var puaseButton: some View {
+    Group {
+      Circle()
+        .frame(width: 64, height: 64)
+        .foregroundColor(Color.white)
+      
+      Image(systemName: "pause.fill")
+        .resizable()
+        .font(.system(size: 32))
+        .frame(width: 28, height: 32)
+        .foregroundColor(Color(hex: "D81B60"))
     }
   }
   
@@ -69,15 +84,7 @@ struct AlbumRecordAddView: View {
           }, label: {
             ZStack {
               if audioRecorder.isRecording { // 녹음 시작
-                Circle()
-                  .frame(width: 64, height: 64)
-                  .foregroundColor(Color.white)
-                
-                Image(systemName: "pause.fill")
-                  .resizable()
-                  .font(.system(size: 32))
-                  .frame(width: 28, height: 32)
-                  .foregroundColor(Color(hex: "D81B60"))
+                puaseButton // 정지 버튼
               } else { // 녹음 끝
                 Circle()
                   .frame(width: 64, height: 64)
@@ -91,7 +98,17 @@ struct AlbumRecordAddView: View {
             }
           })
           if record {
-            playButton // 재생 버튼
+            if audioRecorder.isPlaying == false {
+              playButton // 재생 버튼
+            } else {
+              Button(action: {
+                self.audioRecorder.pausePlayback()
+              }) {
+                ZStack {
+                  puaseButton // 정지 버튼
+                }
+              }
+            }
           }
         }
         .padding(.top, 16)
@@ -122,7 +139,12 @@ struct AlbumRecordAddView: View {
             )
           
           // 날짜 선택으로 이동
-          NavigationLink("", destination: AlbumSelectDateView(title: "녹음 올리기", isCameraCancle: .constant(false), recordParent: self, recordUrl: audioRecorder.url), isActive: $isNext)
+          if isNext {
+            NavigationLink("", destination: AlbumSelectDateView(title: "녹음 올리기", isCameraCancle: .constant(false), recordParent: self, recordUrl: audioRecorder.url), isActive: $isNext)
+              .onAppear {
+                self.audioRecorder.pausePlayback()
+              }
+          }
         }
         .background(Color.black)
         .navigationBarHidden(true)

--- a/Sofa/Sources/View/Album/AlbumRecordAddView/SubViews/ViewModel/AudioRecorderViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumRecordAddView/SubViews/ViewModel/AudioRecorderViewModel.swift
@@ -8,10 +8,14 @@
 import Foundation
 import AVFoundation
 
-class AudioRecorderViewModel: ObservableObject {
+class AudioRecorderViewModel: NSObject, ObservableObject {
   @Published public var soundSamples: [Bool]
   @Published public var isRecording = false
   @Published public var url: URL?
+  
+  // 재생
+  @Published var isPlaying = false
+  var audioPlayer: AVAudioPlayer!
   
   // 시간 Properties
   @Published var minutes: Int = 0
@@ -68,6 +72,7 @@ class AudioRecorderViewModel: ObservableObject {
       try audioSession.setCategory(.playAndRecord, mode: .default, options: [])
       self.isRecording = true // 녹음 시작
       
+      stopInit()
       startMonitoring() // 시간 및 bar 위치 계산
     } catch {
       fatalError(error.localizedDescription)
@@ -83,6 +88,7 @@ class AudioRecorderViewModel: ObservableObject {
     minutes = 0
     time = 0
     audioRecorder.stop()
+    self.startInit(audio: self.url!)
     self.currentStepbar = 0
     self.soundSamples = [Bool](repeating: false, count: numberOfStepbar)
   }
@@ -127,6 +133,85 @@ class AudioRecorderViewModel: ObservableObject {
       try FileManager.default.removeItem(at: urlsToDelete)
     } catch {
       print("File could not be deleted!")
+    }
+  }
+}
+
+//MARK: - 재생
+extension AudioRecorderViewModel: AVAudioPlayerDelegate {
+  func startInit (audio: URL) {
+    let playbackSession = AVAudioSession.sharedInstance()
+    
+    do {
+      try playbackSession.overrideOutputAudioPort(AVAudioSession.PortOverride.speaker)
+    } catch {
+      print("기기의 스피커를 통해 재생하지 못했습니다")
+    }
+    
+    do {
+      audioPlayer = try AVAudioPlayer(contentsOf: audio)
+      audioPlayer.delegate = self
+    } catch {
+      print("재생 실패")
+    }
+  }
+  
+  func startPlayback() {
+    playMonitoring()
+    isPlaying = true
+  }
+  
+  func playMonitoring() {
+    audioPlayer.isMeteringEnabled = true
+    audioPlayer.play()
+    
+    timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true, block: { [self] (timer) in
+      self.audioPlayer.updateMeters()
+      
+      self.currentStepbar = normalizeSoundLevel(level: Float(averagePowerFromAllChannels())) // 음성의 level의 크기에 따라
+      self.soundSamples = [Bool](repeating: true, count: currentStepbar) + [Bool](repeating: false, count:  self.numberOfStepbar - currentStepbar)
+      
+      self.time += 1
+      
+      self.microSeconds = Int(self.time) % 100
+      self.seconds = Int(self.time * 0.01) % 60
+      self.minutes = (Int(self.time * 0.01) / 60) % 60
+    })
+  }
+  
+  // 모든 채널의 평균 power 계산
+  private func averagePowerFromAllChannels() -> CGFloat {
+    var power: CGFloat = 0.0
+    (0..<audioPlayer.numberOfChannels).forEach { (index) in
+      power = power + CGFloat(audioPlayer.averagePower(forChannel: index))
+    }
+    return power / CGFloat(audioPlayer.numberOfChannels)
+  }
+  
+  func pausePlayback() {
+    isPlaying = false
+    audioPlayer.pause()
+    timer.invalidate()
+  }
+  
+  // 재생 정지 & 초기화
+  func stopInit() {
+    if let audioPlayer = audioPlayer {
+      audioPlayer.stop() // play중 녹음버튼을 누를 경우,
+    }
+    timer.invalidate()
+    microSeconds = 0
+    seconds = 0
+    minutes = 0
+    time = 0
+    self.currentStepbar = 0
+    self.soundSamples = [Bool](repeating: false, count: numberOfStepbar)
+  }
+  
+  func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+    if flag {
+      stopInit()
+      isPlaying = false
     }
   }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 녹음 업로드 전, 녹음 재생/정지

🌱 PR 포인트
- AlbumRecordAddView(UI)와 AudioRecorderViewModel(Action)만 보시면 됩니다.
- UI : AlbumRecordAddView에 재생/정지일 경우에 따라, UI가 변경이 됩니다.
- Action : AudioRecorderViewModel를 통해 오디오 재생/녹음을 컨트롤했습니다.
  - func averagePowerFromAllChannels() : 모든 채널의 평균 power를 계산 -> 이것이 계산되어야 녹음된 소리의 크기를 알수 있습니다.
  - stop이 아닌 pause를 위해 func pausePlayback()를 구현했습니다.


## 📸 스크린샷
|![녹음 듣기](https://user-images.githubusercontent.com/48436020/180125232-80a99af5-0bbb-4329-851e-017b4d3bd10e.gif)|
|:-:|
|재생/정지|

## 📮 관련 이슈
- Resolved: #116 
