### PR TITLE
[FEAT] 댓글 API

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -540,16 +540,16 @@
 			isa = PBXGroup;
 			children = (
 				C4EC31CA284F8CBB0049F2C4 /* Album.swift */,
-				C4AC885B2886A52600BA5921 /* UploadFile.swift */,
 				C495F5F9285630C0009B3BDE /* AlbumDetail.swift */,
-				0AAB367E286381C000A47B24 /* HomeInfo.swift */,
-				0A2887F52870A80B000A72F2 /* FamilyList.swift */,
-				6FE6D78A2861B1B100E3C21E /* DateValue.swift */,
 				6F0974342861E53A0000956C /* CalendarTask.swift */,
-				0AE492052876A9B000341D35 /* HistoryInfo.swift */,
 				C481B6D8287ADF0C005D6831 /* Comment.swift */,
-				0A915DD6287A9BA00055AD6D /* Notifications.swift */,
+				6FE6D78A2861B1B100E3C21E /* DateValue.swift */,
+				0A2887F52870A80B000A72F2 /* FamilyList.swift */,
 				0AF2B5412884601B00C6A55E /* LoginResponse.swift */,
+				0A915DD6287A9BA00055AD6D /* Notifications.swift */,
+				0AE492052876A9B000341D35 /* HistoryInfo.swift */,
+				0AAB367E286381C000A47B24 /* HomeInfo.swift */,
+				C4AC885B2886A52600BA5921 /* UploadFile.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		C4AC88672889BC0900BA5921 /* AlbumDetailListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AC88662889BC0900BA5921 /* AlbumDetailListViewModel.swift */; };
 		C4AC886A288B8AFA00BA5921 /* AlbumEditViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AC8869288B8AFA00BA5921 /* AlbumEditViewModel.swift */; };
 		C4AC886D288D86BD00BA5921 /* AlbumDetailListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AC886C288D86BD00BA5921 /* AlbumDetailListCellViewModel.swift */; };
+		C4AC886F288EE3D300BA5921 /* CommentManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4AC886E288EE3D300BA5921 /* CommentManger.swift */; };
 		C4B4963528800DDF000C9E1F /* AlbumListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4963428800DDF000C9E1F /* AlbumListViewModel.swift */; };
 		C4B4963928801E5D000C9E1F /* AlbumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B4963828801E5D000C9E1F /* AlbumManager.swift */; };
 		C4B8F2952850DA1C0000B8CB /* AlbumActionSheetItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B8F2942850DA1C0000B8CB /* AlbumActionSheetItem.swift */; };
@@ -337,6 +338,7 @@
 		C4AC88662889BC0900BA5921 /* AlbumDetailListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailListViewModel.swift; sourceTree = "<group>"; };
 		C4AC8869288B8AFA00BA5921 /* AlbumEditViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumEditViewModel.swift; sourceTree = "<group>"; };
 		C4AC886C288D86BD00BA5921 /* AlbumDetailListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumDetailListCellViewModel.swift; sourceTree = "<group>"; };
+		C4AC886E288EE3D300BA5921 /* CommentManger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentManger.swift; sourceTree = "<group>"; };
 		C4B4963428800DDF000C9E1F /* AlbumListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumListViewModel.swift; sourceTree = "<group>"; };
 		C4B4963828801E5D000C9E1F /* AlbumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumManager.swift; sourceTree = "<group>"; };
 		C4B8F2942850DA1C0000B8CB /* AlbumActionSheetItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumActionSheetItem.swift; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 				C4B4963828801E5D000C9E1F /* AlbumManager.swift */,
 				C4AC88562886A15000BA5921 /* UploadManager.swift */,
 				C4AC88632889B29D00BA5921 /* AlbumDetailManger.swift */,
+				C4AC886E288EE3D300BA5921 /* CommentManger.swift */,
 				C4AC885F28896ADB00BA5921 /* APIConstants.swift */,
 				0AF2B5432884613D00C6A55E /* LoginManager.swift */,
 			);
@@ -1449,6 +1452,7 @@
 				C4667A31284B6FF200A4A759 /* ContentView.swift in Sources */,
 				0AF2B5442884613D00C6A55E /* LoginManager.swift in Sources */,
 				C481B6D9287ADF0C005D6831 /* Comment.swift in Sources */,
+				C4AC886F288EE3D300BA5921 /* CommentManger.swift in Sources */,
 				C495F613285B7FDE009B3BDE /* ZoomScrollView.swift in Sources */,
 				6FBCD635287AFA9700D874FD /* Highlighting.swift in Sources */,
 				C495F617285B95BB009B3BDE /* AlbumRecordNavigationBar.swift in Sources */,
@@ -1693,7 +1697,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sofa/Configuration/Assets\"";
-				DEVELOPMENT_TEAM = B4G53F63TN;
+				DEVELOPMENT_TEAM = SF6SBNPMLX;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Sofa/Info.plist;

--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -557,12 +557,12 @@
 		6F22E52E284B9D220069D268 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				C4AC885F28896ADB00BA5921 /* APIConstants.swift */,
 				C4B4963828801E5D000C9E1F /* AlbumManager.swift */,
-				C4AC88562886A15000BA5921 /* UploadManager.swift */,
 				C4AC88632889B29D00BA5921 /* AlbumDetailManger.swift */,
 				C4AC886E288EE3D300BA5921 /* CommentManger.swift */,
-				C4AC885F28896ADB00BA5921 /* APIConstants.swift */,
 				0AF2B5432884613D00C6A55E /* LoginManager.swift */,
+				C4AC88562886A15000BA5921 /* UploadManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";

--- a/Sofa/Sources/Models/Comment.swift
+++ b/Sofa/Sources/Models/Comment.swift
@@ -7,11 +7,12 @@
 
 import Foundation
 
-struct Comments: Decodable {
+struct CommensAPIResponse: Decodable {
   var comments: [Comment]
 }
 
 struct Comment: Decodable {
+  var writerId: Int
   var profileLink: String
   var nickname: String
   var roleInFamily: String
@@ -19,7 +20,7 @@ struct Comment: Decodable {
   var content: String
   
   static func getDummy() -> Self{
-    return Comment(profileLink: "", nickname: "별명", roleInFamily: "엄마", createdDate: "2022-07-04 20:20:00", content: "또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다 \n댓글에 \n계속 \n줄바꿈을 \n누를 \n때 \n별다른 \n제한은 \n없다.\n\n\n\n")
+    return Comment(writerId: 0, profileLink: "", nickname: "별명", roleInFamily: "엄마", createdDate: "2022-07-04 20:20:00", content: "또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다또 놀러가고싶다 \n댓글에 \n계속 \n줄바꿈을 \n누를 \n때 \n별다른 \n제한은 \n없다.\n\n\n\n")
   }
   
   // 마지막 공백 제거하여 반환

--- a/Sofa/Sources/Network/CommentManger.swift
+++ b/Sofa/Sources/Network/CommentManger.swift
@@ -1,0 +1,66 @@
+//
+//  CommentManger.swift
+//  Sofa
+//
+//  Created by geonhyeong on 2022/07/25.
+//
+
+import Alamofire
+import Combine
+
+enum CommentManger: URLRequestConvertible {
+  
+  case getComments(fileId: Int)
+
+  var baseURL: URL {
+    switch self {
+    case let .getComments(fileId):
+      return URL(string: "\(APIConstants.url)/album/\(fileId)/comments")!
+    }
+  }
+  
+  var method: HTTPMethod {
+    switch self {
+    case .getComments:
+      return .get
+    }
+  }
+  
+  var headers: HTTPHeaders {
+    var headers = HTTPHeaders()
+    let accessToken = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJLQUtBTzoyMTczNzMzODA0IiwiaWF0IjoxNjU4MDM4NzA0LCJleHAiOjE2NjU4MTQ3MDR9.Cm1pEFN83ribamFh36WdnSTJI74Crmy2T9XmxElwr1Q"
+    headers["Authorization"] = accessToken
+    
+    switch self {
+    case .getComments:
+      headers["Content-Type"] = "application/json"
+    }
+    return headers
+  }
+  
+//  var parameters: Parameters {
+//    var params = Parameters()
+//
+//    switch self {
+//    case .getComments:
+//      break
+//    }
+//    return params
+//  }
+  
+  func asURLRequest() throws -> URLRequest {
+    let url = baseURL
+    
+    var request = URLRequest(url: url)
+    request.method = method
+    request.headers = headers
+    
+    switch self {
+    case .getComments:
+      request = try URLEncoding.default.encode(request, with: nil)
+    }
+    
+    return request
+  }
+}
+

--- a/Sofa/Sources/Network/CommentManger.swift
+++ b/Sofa/Sources/Network/CommentManger.swift
@@ -12,14 +12,16 @@ enum CommentManger: URLRequestConvertible {
   
   case getComments(fileId: Int)
   case postComments(writerId: Int, fileId: Int, content: String)
-
+  case patchComment(commentId: Int, content: String)
+  
   var baseURL: URL {
     switch self {
     case let .getComments(fileId):
       return URL(string: "\(APIConstants.url)/album/\(fileId)/comments")!
     case let .postComments(_, fileId, _):
       return URL(string: "\(APIConstants.url)/album/\(fileId)/comments")!
-
+    case let .patchComment(commentId, _):
+      return URL(string: "\(APIConstants.url)/album/comments/\(commentId)")!
     }
   }
   
@@ -29,6 +31,8 @@ enum CommentManger: URLRequestConvertible {
       return .get
     case .postComments:
       return .post
+    case .patchComment:
+      return .patch
     }
   }
   
@@ -42,6 +46,8 @@ enum CommentManger: URLRequestConvertible {
       headers["Content-Type"] = "application/json"
     case .postComments:
       headers["Content-Type"] = "application/json"
+    case .patchComment:
+      headers["Content-Type"] = "application/json"
     }
     return headers
   }
@@ -53,6 +59,8 @@ enum CommentManger: URLRequestConvertible {
     case .getComments:
       break
     case let .postComments(_, _, content):
+      params["content"] = content
+    case let .patchComment(_, content):
       params["content"] = content
     }
     return params
@@ -69,6 +77,8 @@ enum CommentManger: URLRequestConvertible {
     case .getComments:
       request = try URLEncoding.default.encode(request, with: nil)
     case .postComments:
+      request.httpBody = try JSONEncoding.default.encode(request, with: parameters).httpBody
+    case .patchComment:
       request.httpBody = try JSONEncoding.default.encode(request, with: parameters).httpBody
     }
     

--- a/Sofa/Sources/Network/CommentManger.swift
+++ b/Sofa/Sources/Network/CommentManger.swift
@@ -11,11 +11,15 @@ import Combine
 enum CommentManger: URLRequestConvertible {
   
   case getComments(fileId: Int)
+  case postComments(writerId: Int, fileId: Int, content: String)
 
   var baseURL: URL {
     switch self {
     case let .getComments(fileId):
       return URL(string: "\(APIConstants.url)/album/\(fileId)/comments")!
+    case let .postComments(_, fileId, _):
+      return URL(string: "\(APIConstants.url)/album/\(fileId)/comments")!
+
     }
   }
   
@@ -23,6 +27,8 @@ enum CommentManger: URLRequestConvertible {
     switch self {
     case .getComments:
       return .get
+    case .postComments:
+      return .post
     }
   }
   
@@ -34,19 +40,23 @@ enum CommentManger: URLRequestConvertible {
     switch self {
     case .getComments:
       headers["Content-Type"] = "application/json"
+    case .postComments:
+      headers["Content-Type"] = "application/json"
     }
     return headers
   }
   
-//  var parameters: Parameters {
-//    var params = Parameters()
-//
-//    switch self {
-//    case .getComments:
-//      break
-//    }
-//    return params
-//  }
+  var parameters: Parameters {
+    var params = Parameters()
+
+    switch self {
+    case .getComments:
+      break
+    case let .postComments(_, _, content):
+      params["content"] = content
+    }
+    return params
+  }
   
   func asURLRequest() throws -> URLRequest {
     let url = baseURL
@@ -58,6 +68,8 @@ enum CommentManger: URLRequestConvertible {
     switch self {
     case .getComments:
       request = try URLEncoding.default.encode(request, with: nil)
+    case .postComments:
+      request.httpBody = try JSONEncoding.default.encode(request, with: parameters).httpBody
     }
     
     return request

--- a/Sofa/Sources/View/Album/AlbumCommentView/AlbumCommentView.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/AlbumCommentView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AlbumCommentView: View {
   @Binding var isShowing: Bool
+  let filedId: Int
   
   var body: some View {
     ZStack(alignment: .bottom) {
@@ -17,7 +18,7 @@ struct AlbumCommentView: View {
           self.isShowing = false
         }
         
-        CommentModal() { // 댓글 Modal
+        CommentModal(filedId: filedId) { // 댓글 Modal
           self.isShowing = false
         }
         .transition(.move(edge: .bottom))
@@ -31,6 +32,6 @@ struct AlbumCommentView: View {
 
 struct AlbumCommentView_Previews: PreviewProvider {
   static var previews: some View {
-    AlbumCommentView(isShowing: .constant(true))
+    AlbumCommentView(isShowing: .constant(true), filedId: 0)
   }
 }

--- a/Sofa/Sources/View/Album/AlbumCommentView/AlbumCommentView.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/AlbumCommentView.swift
@@ -18,7 +18,7 @@ struct AlbumCommentView: View {
           self.isShowing = false
         }
         
-        CommentModal(filedId: filedId) { // 댓글 Modal
+        CommentModal(viewModel: CommentViewModel(filedId: filedId)) { // 댓글 Modal
           self.isShowing = false
         }
         .transition(.move(edge: .bottom))

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/CommentModal/CommentModal.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/CommentModal/CommentModal.swift
@@ -12,6 +12,7 @@ struct CommentModal: View {
   @State private var prevDragTranslation = CGSize.zero
   @State private var isDragging = false
   @State var isWriteClick = false
+  let filedId: Int
   let minHeight: CGFloat = Screen.maxHeight / 2
   let maxHeight: CGFloat = Screen.maxHeight * 0.9
   var callback: (() -> ())? = nil
@@ -39,7 +40,7 @@ struct CommentModal: View {
         isDragging = true
         
         let dragAmount = value.translation.height - prevDragTranslation.height
-//        
+
         if curHeight > maxHeight || curHeight < minHeight {
           curHeight -= dragAmount / 6
         } else{
@@ -81,7 +82,7 @@ struct CommentModal: View {
     VStack(alignment: .center, spacing: 0) {
       topHalfMiddleBar // top bar
       
-      AlbumCommentList()
+      AlbumCommentList(viewModel: CommentViewModel(filedId: filedId))
       
       Divider()
         .overlay(Color(hex: "EDEADF"))
@@ -105,7 +106,7 @@ struct CommentModal_Previews: PreviewProvider {
     ZStack(alignment: .bottom) {
       ModalBackGround() // Back Ground
       
-      CommentModal() // 댓글 Modal
+      CommentModal(filedId: 0) // 댓글 Modal
         .transition(.move(edge: .bottom))
     }
   }

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/CommentModal/CommentModal.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/CommentModal/CommentModal.swift
@@ -8,11 +8,13 @@
 import SwiftUI
 
 struct CommentModal: View {
+  @StateObject var viewModel: CommentViewModel
   @State private var curHeight: CGFloat = Screen.maxHeight / 2
   @State private var prevDragTranslation = CGSize.zero
   @State private var isDragging = false
   @State var isWriteClick = false
-  let filedId: Int
+  @State var commentText: String?
+  @State var placeholder = "댓글을 남겨보세요"
   let minHeight: CGFloat = Screen.maxHeight / 2
   let maxHeight: CGFloat = Screen.maxHeight * 0.9
   var callback: (() -> ())? = nil
@@ -82,7 +84,7 @@ struct CommentModal: View {
     VStack(alignment: .center, spacing: 0) {
       topHalfMiddleBar // top bar
       
-      AlbumCommentList(viewModel: CommentViewModel(filedId: filedId))
+      AlbumCommentList(viewModel: viewModel)
       
       Divider()
         .overlay(Color(hex: "EDEADF"))
@@ -93,9 +95,19 @@ struct CommentModal: View {
       Spacer()
         .frame(height: Screen.safeAreaBottom)
     }
+    .fullScreenCover(isPresented: $isWriteClick) {
+      MessageView($isWriteClick, $commentText, $placeholder)
+        .background(BackgroundCleanerView())
+        .onDisappear {
+          if let commentText = commentText {
+            self.viewModel.writeComment(content: commentText) // 댓글 전송
+            self.commentText = nil // 댓글 초기화
+          }
+        }
+    }
     .background(Color.white)
     .cornerRadius(16)
-    .frame(height: curHeight)
+    .frame(height: isWriteClick ? 0 : curHeight) // 댓글 View가 나타날때
     .frame(maxWidth: .infinity)
     .animation(isDragging ? nil : .easeInOut(duration: 0.45))
   }
@@ -106,7 +118,7 @@ struct CommentModal_Previews: PreviewProvider {
     ZStack(alignment: .bottom) {
       ModalBackGround() // Back Ground
       
-      CommentModal(filedId: 0) // 댓글 Modal
+      CommentModal(viewModel: CommentViewModel(filedId: 0)) // 댓글 Modal
         .transition(.move(edge: .bottom))
     }
   }

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentList.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentList.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AlbumCommentList: View {
-  @StateObject var viewModel = CommentViewModel()
+  @StateObject var viewModel: CommentViewModel
 
   var body: some View {
     ScrollView {
@@ -21,14 +21,11 @@ struct AlbumCommentList: View {
         }
       }
     }
-    .onAppear {
-      self.viewModel.fetchComment()
-    }
   }
 }
 
 struct AlbumCommentList_Previews: PreviewProvider {
   static var previews: some View {
-    AlbumCommentList()
+    AlbumCommentList(viewModel: CommentViewModel(filedId: 0))
   }
 }

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentRow.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentRow.swift
@@ -13,7 +13,7 @@ struct AlbumCommentRow: View {
 
   var body: some View {
     HStack(alignment: .top, spacing: 16) {
-      if comment.profileLink == "defaultImage" || URL(string: comment.profileLink) != nil { // link를 받아오지 못하거나, default 이미지 일경우
+      if comment.profileLink == "defaultImage" || URL(string: comment.profileLink) == nil { // link를 받아오지 못하거나, default 이미지 일경우
         Image("lionprofile") // 이미지
           .resizable()
           .frame(width: 48, height: 48)
@@ -46,6 +46,8 @@ struct AlbumCommentRow: View {
             .font(.custom("Pretendard-Medium", size: 13))
             .foregroundColor(Color.secondary)
             .padding(.trailing, 16)
+          
+          
         }
         
         Text("\(comment.descriptionContent)") // 댓글

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentRow.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentRow.swift
@@ -6,16 +6,27 @@
 //
 
 import SwiftUI
+import URLImage
 
 struct AlbumCommentRow: View {
   var comment: Comment
 
   var body: some View {
     HStack(alignment: .top, spacing: 16) {
-      Image("lionprofile") // 이미지
-        .resizable()
-        .frame(width: 48, height: 48)
-        .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+      if comment.profileLink == "defaultImage" || URL(string: comment.profileLink) != nil { // link를 받아오지 못하거나, default 이미지 일경우
+        Image("lionprofile") // 이미지
+          .resizable()
+          .frame(width: 48, height: 48)
+          .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+
+      } else {
+        URLImage(url: URL(string: comment.profileLink)!, content: { image in
+          image
+            .resizable()
+            .frame(width: 48, height: 48)
+            .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+        })
+      }
       
       VStack(alignment: .leading) { // 댓글 정보
         HStack(alignment: .center, spacing: 8) { // 댓글 작성자 정보

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentRow.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentRow.swift
@@ -10,7 +10,7 @@ import URLImage
 
 struct AlbumCommentRow: View {
   var comment: Comment
-
+  
   var body: some View {
     HStack(alignment: .top, spacing: 16) {
       if comment.profileLink == "defaultImage" || URL(string: comment.profileLink) == nil { // link를 받아오지 못하거나, default 이미지 일경우
@@ -18,7 +18,7 @@ struct AlbumCommentRow: View {
           .resizable()
           .frame(width: 48, height: 48)
           .padding(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
-
+        
       } else {
         URLImage(url: URL(string: comment.profileLink)!, content: { image in
           image
@@ -42,12 +42,20 @@ struct AlbumCommentRow: View {
           
           Spacer()
           
-          Text("\(comment.descriptionDate)") // 날짜
-            .font(.custom("Pretendard-Medium", size: 13))
-            .foregroundColor(Color.secondary)
-            .padding(.trailing, 16)
-          
-          
+          HStack(spacing: 5) {
+            Text("\(comment.descriptionDate)") // 날짜
+              .font(.custom("Pretendard-Medium", size: 13))
+              .foregroundColor(Color(hex: "999999"))
+            Button(action: {
+              
+            }) {
+              Image(systemName: "ellipsis")
+                .frame(width: 20, height: 20)
+                .foregroundColor(Color(hex: "999999"))
+                .font(.system(size: 20))
+            }
+          }
+          .padding(.trailing, 16)
         }
         
         Text("\(comment.descriptionContent)") // 댓글

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/ViewModel/CommentViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/ViewModel/CommentViewModel.swift
@@ -68,5 +68,24 @@ class CommentViewModel: ObservableObject{
       )
       .store(in: &subscription)   // disposed(by: disposeBag)
   }
+  
+  // 댓글 수정
+  func editComment(commentId: Int, content: String) {
+    AF.request(CommentManger.patchComment(commentId: commentId, content: content))
+      .publishDecodable(type: AlbumDefaulAPIResponse.self)
+      .value()
+      .receive(on: DispatchQueue.main)
+      .sink(
+        receiveCompletion: {completion in
+          guard case .failure(let error) = completion else { return }
+          NSLog("Error : " + error.localizedDescription)
+          self.fetchComments()
+        },
+        receiveValue: {receivedValue in
+          NSLog("받은 값 : \(receivedValue)")
+        }
+      )
+      .store(in: &subscription)   // disposed(by: disposeBag)
+  }
 }
 

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/ViewModel/CommentViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/ViewModel/CommentViewModel.swift
@@ -49,5 +49,24 @@ class CommentViewModel: ObservableObject{
       )
       .store(in: &subscription)   // disposed(by: disposeBag)
   }
+  
+  // 댓글 작성
+  func writeComment(content: String) {
+    AF.request(CommentManger.postComments(writerId: 0, fileId: filedId, content: content))
+      .publishDecodable(type: AlbumDefaulAPIResponse.self)
+      .value()
+      .receive(on: DispatchQueue.main)
+      .sink(
+        receiveCompletion: {completion in
+          guard case .failure(let error) = completion else { return }
+          NSLog("Error : " + error.localizedDescription)
+          self.fetchComments()
+        },
+        receiveValue: {receivedValue in
+          NSLog("받은 값 : \(receivedValue)")
+        }
+      )
+      .store(in: &subscription)   // disposed(by: disposeBag)
+  }
 }
 

--- a/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumImageDetailView/AlbumImageDetailView.swift
@@ -104,7 +104,7 @@ struct AlbumImageDetailView: View {
         AlbumDateEditView(fileId: info!.fileId) // 임시
       }
       .fullScreenCover(isPresented: $isCommentClick) {
-        AlbumCommentView(isShowing: $isCommentClick)
+        AlbumCommentView(isShowing: $isCommentClick, filedId: info!.fileId)
           .background(BackgroundCleanerView())
       }
       .onAppear {

--- a/Sofa/Sources/View/Album/AlbumRecordDetailView/AlbumRecordDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumRecordDetailView/AlbumRecordDetailView.swift
@@ -229,7 +229,7 @@ struct AlbumRecordDetailView: View {
         AlbumDateEditView(fileId: info!.fileId) // 임시
       }
       .fullScreenCover(isPresented: $isCommentClick) {
-        AlbumCommentView(isShowing: $isCommentClick)
+        AlbumCommentView(isShowing: $isCommentClick, filedId: info!.fileId)
           .background(BackgroundCleanerView())
       }
       .onAppear {

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -14,6 +14,7 @@ struct HomeView: View {
   @State var showModal = false
   @State var showMessageView = false
   @Binding var selectionType: Tab
+  @State var text: String?
   @State var placeholder = "가족에게 인사를 남겨보세요."
   @State var currentSelectedTab: Tab = .home // 현재 선택된 탭으로 표시할 곳
   
@@ -72,7 +73,7 @@ struct HomeView: View {
             .padding(.horizontal, 23)
             .edgesIgnoringSafeArea(.all)
             .fullScreenCover(isPresented: $showMessageView) {
-              MessageView($showMessageView, $placeholder)
+              MessageView($showMessageView, $text, $placeholder)
                 .background(BackgroundCleanerView())
             }
           

--- a/Sofa/Sources/View/Home/MessageView.swift
+++ b/Sofa/Sources/View/Home/MessageView.swift
@@ -19,8 +19,8 @@ struct MessageView: View {
   @StateObject var keyboardHeightHelper = KeyboardHeightHelper()
   
   @Binding var isShowing: Bool // 외부 View에서 MessageView 띄울 때 사용
+  @Binding var text: String? // TextEditor의 Text
   @State private var isDragging = false
-  @State private var text: String? // TextEditor의 Text
   @State private var textLength: Int = 0 // 글자 수 세기
   @State private var curHeight: CGFloat = 120 // View의 현재 높이
   @State var minHeight: CGFloat = 120 // View의 최소 높이
@@ -29,12 +29,12 @@ struct MessageView: View {
   @State var fullTextEditorHeight: CGFloat = 0 // TextEditor가 Full일 때 높이
   @State var isKeyboard: Bool = false // 현재 키보드 올라와있는지
   @State var firstResponder: FirstResponders? = Sofa.FirstResponders.text
-  
-  init(_ isShowing: Binding<Bool>, _ placeholder: Binding<String>){
+
+  init(_ isShowing: Binding<Bool>, _ text: Binding<String?>, _ placeholder: Binding<String>){
     UITextView.appearance().backgroundColor = .clear
     _isShowing = isShowing
+    _text = text
     _placeholder = placeholder
-    
   }
   
   var body: some View {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 댓글 List 조회 API
- 댓글 입력 API
- 댓글 수정 API (done은 아니지만 미리 만들어 놨습니다)

🌱 PR 포인트
### 같이 사용하는 Model과 Network에 있는 파일을 알파벳 순서대로 고쳐놨습니다. 충돌에 대비하세요 😭
- 유진님의 MessageView의 코드를 수정했습니다. 그래서 HomeView의 코드도 수정하게 되었습니다.
- HomeView의 17번째 줄의 **@State var text: String? // 작성한 글**이 추가 되었습니다.
- 댓글 전송을 위해 MessageView의 **text(State)**을 Binding<String?>으로 수정했습니다.
- 아래 처럼 사용하게 되었습니다.

``` swift
@State private var text: String?

view
.fullScreenCover(isPresented: $isWriteClick) {
  MessageView($isWriteClick, $commentText, $placeholder)
    .background(BackgroundCleanerView())
    .onDisappear {
      if let commentText = commentText {
        self.viewModel.writeComment(content: commentText) // 댓글 전송
        self.commentText = nil // 댓글 초기화
      }
    }
}
.frame(height: isWriteClick ? 0 : curHeight) // 댓글 View가 나타날때
```
- PR은 내일 오전 12시쯤 하겠습니다.

## 📮 관련 이슈
- Resolved: #129 
