### PR TITLE
[FIX] 앨범 API Update UI + 녹음 다운로드

### DIFF
--- a/Sofa/Configuration/ViewModifiers/NavigationBarWithTextButtonStyle.swift
+++ b/Sofa/Configuration/ViewModifiers/NavigationBarWithTextButtonStyle.swift
@@ -52,6 +52,7 @@ struct NavigationBarWithTextButtonStyle: ViewModifier {
             }) {
               Text(title)
                 .font(.custom("Pretendard-Medium", size: 16))
+                .foregroundColor(Color.primary)
                 .bold()
             }
             .disabled(isDisalbeTitleButton)

--- a/Sofa/Configuration/ViewModifiers/NavigationBarWithTextButtonStyle.swift
+++ b/Sofa/Configuration/ViewModifiers/NavigationBarWithTextButtonStyle.swift
@@ -52,7 +52,6 @@ struct NavigationBarWithTextButtonStyle: ViewModifier {
             }) {
               Text(title)
                 .font(.custom("Pretendard-Medium", size: 16))
-                .foregroundColor(Color.black)
                 .bold()
             }
             .disabled(isDisalbeTitleButton)

--- a/Sofa/Sources/Models/AlbumDetail.swift
+++ b/Sofa/Sources/Models/AlbumDetail.swift
@@ -25,7 +25,7 @@ struct AlbumDetailElement: Identifiable, Hashable, Decodable {
   let fileId: Int
   let date: String
   let link: String
-  let favourite: Bool
+  var favourite: Bool
   let commentCount: Int
 }
 

--- a/Sofa/Sources/Network/AlbumDetailManger.swift
+++ b/Sofa/Sources/Network/AlbumDetailManger.swift
@@ -83,8 +83,10 @@ enum AlbumDetailManger: URLRequestConvertible {
     switch self {
     case .getAlbumDetailListByDate:
       break
-    case let .getAlbumDetailListByKind(kind, _, _):
+    case let .getAlbumDetailListByKind(kind, page, size):
       params["kind"] = kind
+      params["page"] = page
+      params["size"] = size
     case let .patchAlbumTitle(_, title):
       params["albumName"] = title
     case let .patchAlbumDate(_, date):

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentList.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentList.swift
@@ -28,6 +28,7 @@ struct AlbumCommentList: View {
             Text("말을 걸어 대화를 시작해보세요") // 별명
               .font(.custom("Pretendard-Medium", size: 16))
           }
+          .foregroundColor(Color.black)
         }
       }
     }

--- a/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentList.swift
+++ b/Sofa/Sources/View/Album/AlbumCommentView/SubViews/Row/AlbumCommentList.swift
@@ -19,6 +19,16 @@ struct AlbumCommentList: View {
             .padding(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
             .animationsDisabled()
         }
+        
+        // 댓글이 없을 경우
+        if viewModel.comments.count == 0 {
+          VStack(spacing: 10) {
+            Text("아직 댓글이 없습니다") // 별명
+              .font(.custom("Pretendard-Bold", size: 16))
+            Text("말을 걸어 대화를 시작해보세요") // 별명
+              .font(.custom("Pretendard-Medium", size: 16))
+          }
+        }
       }
     }
   }

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -7,13 +7,13 @@
 
 import SwiftUI
 import URLImage
-import Photos
 
 struct AlbumDetailView: View {
   @Environment(\.presentationMode) var presentable
   @ObservedObject var tabbarManager = TabBarManager.shared
   @ObservedObject var authorizationViewModel = AuthorizationViewModel()
-
+  @ObservedObject var audioViewModel = AudioRecorderViewModel(numberOfSamples: 21)
+  
   @State var isTitleClick = false
   @State var isEdit = false
   
@@ -29,9 +29,9 @@ struct AlbumDetailView: View {
   
   @State var isPhotoCommentClick: Bool = false   // 사진 댓글
   @State var isRecordingCommentClick: Bool = false   // 녹음 댓글
-
+  
   @State var isEllipsisClick: Bool = false  // 사진 설정
-
+  
   // Toast Message
   @State var isToastMessage: Bool = false
   @State var messageData2: ToastMessage.MessageData = ToastMessage.MessageData(title: "다운로드 완료", type: .Registration)
@@ -48,7 +48,14 @@ struct AlbumDetailView: View {
         ActionSheetCardItem(systemIconName: "arrow.down", label: "다운로드") {
           isEllipsisClick = false
           messageData2 = ToastMessage.MessageData(title: "다운로드 완료", type: .Registration)
-          authorizationViewModel.showPhotoAlbum(selectImage: selectImage) // 권한 확인
+          
+          if selectFile?.kind == "PHOTO" {
+            authorizationViewModel.showPhotoAlbum(selectImage: selectImage) // 권한 확인
+          } else if selectFile?.kind == "RECORDING" {
+            audioViewModel.download(link: selectFile!.link) { complete in
+              isToastMessage = complete
+            }
+          }
         },
         ActionSheetCardItem(systemIconName: "calendar", label: "날짜 수정") {
           isUpdateDate = true

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -52,7 +52,7 @@ struct AlbumDetailView: View {
           if selectFile?.kind == "PHOTO" {
             authorizationViewModel.showPhotoAlbum(selectImage: selectImage) // 권한 확인
           } else if selectFile?.kind == "RECORDING" {
-            audioViewModel.download(link: selectFile!.link) { complete in
+            audioViewModel.download(fileName: selectFile?.title, link: selectFile!.link) { complete in
               isToastMessage = complete
             }
           }

--- a/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/AlbumDetailView.swift
@@ -68,7 +68,7 @@ struct AlbumDetailView: View {
   var body: some View {
     ZStack {
       NavigationView {
-        VStack(spacing: 0) {
+        ZStack {
           AlbumDetailList(viewModel: AlbumDetailListViewModel(albumId: selectAlbumId, kindType: selectKindType), isPhotoThumbnailClick: $isPhotoThumbnailClick, isRecordingThumbnailClick: $isRecordingThumbnailClick, selectFile: $selectFile, selectImage: $selectImage, isBookmarkClick: $isBookmarkClick, isPhotoCommentClick: $isPhotoCommentClick, isRecordingCommentClick: $isRecordingCommentClick, isEllipsisClick: $isEllipsisClick, selectAlbumId: selectAlbumId, selectKindType: selectKindType)
           
           // 이미지 click

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailList.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailList.swift
@@ -37,7 +37,7 @@ struct AlbumDetailList: View {
       // 필요할때 rendering 함, network에 적합
       LazyVStack(spacing: 0) {
         ForEach(Array(zip(viewModel.albumDetailList.indices, viewModel.albumDetailList)), id: \.0) { index, element in
-          AlbumDetailRow(viewModel: AlbumDetailListCellViewModel(fileId: element.fileId, isFavourite: element.favourite), isPhotoThumbnailClick: $isPhotoThumbnailClick, isRecordingThumbnailClick: $isRecordingThumbnailClick, selectFile: $selectFile, selectImage: $selectImage, isBookmarkClick: $isBookmarkClick, isPhotoCommentClick: $isPhotoCommentClick, isRecordingCommentClick: $isRecordingCommentClick, isEllipsisClick: $isEllipsisClick, info: element, index: index)
+          AlbumDetailRow(viewModel: AlbumDetailListCellViewModel(fileId: element.fileId, isFavourite: element.favourite), listViewModel: viewModel, isPhotoThumbnailClick: $isPhotoThumbnailClick, isRecordingThumbnailClick: $isRecordingThumbnailClick, selectFile: $selectFile, selectImage: $selectImage, isBookmarkClick: $isBookmarkClick, isPhotoCommentClick: $isPhotoCommentClick, isRecordingCommentClick: $isRecordingCommentClick, isEllipsisClick: $isEllipsisClick, info: element, index: index)
             .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
         }
       }

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -152,6 +152,9 @@ struct AlbumDetailRow: View {
         Button(action: {
           isEllipsisClick = true
           selectFile = info
+          if info.kind == "PHOTO" {
+            saveUIImage()
+          }
         }) {
           Image(systemName: "ellipsis")
             .frame(width: 20, height: 20)

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -106,9 +106,14 @@ struct AlbumDetailRow: View {
       
       HStack {
         Button(action: {
-          viewModel.fetchAlbumDetailByDate(viewModel: listViewModel)
-          if !viewModel.isFavourite {
+          viewModel.fetchAlbumDetailByDate()
+          if !viewModel.isFavourite { // 즐겨찾기 해제
             isBookmarkClick = true
+            listViewModel.albumDetailList[index].favourite = true
+          } else if listViewModel.type == "favourite" {
+            listViewModel.albumDetailList.remove(at: index)
+          } else {
+            listViewModel.albumDetailList[index].favourite = false
           }
         }) {
           // 북마크

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -10,6 +10,7 @@ import URLImage
 
 struct AlbumDetailRow: View {
   @ObservedObject var viewModel: AlbumDetailListCellViewModel
+  @ObservedObject var listViewModel: AlbumDetailListViewModel
 
   @Binding var isPhotoThumbnailClick: Bool
   @Binding var isRecordingThumbnailClick: Bool
@@ -105,7 +106,7 @@ struct AlbumDetailRow: View {
       
       HStack {
         Button(action: {
-          viewModel.fetchAlbumDetailByDate()
+          viewModel.fetchAlbumDetailByDate(viewModel: listViewModel)
           if !viewModel.isFavourite {
             isBookmarkClick = true
           }
@@ -163,6 +164,6 @@ struct AlbumDetailRow_Previews: PreviewProvider {
   static var previews: some View {
     let data = MockData().albumDetail.results.elements[3]
     
-    AlbumDetailRow(viewModel: AlbumDetailListCellViewModel(fileId: -1, isFavourite: false), isPhotoThumbnailClick: .constant(false), isRecordingThumbnailClick: .constant(false), selectFile: .constant(data), selectImage: .constant(UIImage()), isBookmarkClick: .constant(false), isPhotoCommentClick: .constant(false), isRecordingCommentClick: .constant(false), isEllipsisClick: .constant(false), info: data, index: 0)
+    AlbumDetailRow(viewModel: AlbumDetailListCellViewModel(fileId: -1, isFavourite: false), listViewModel: AlbumDetailListViewModel(albumId: nil, kindType: nil), isPhotoThumbnailClick: .constant(false), isRecordingThumbnailClick: .constant(false), selectFile: .constant(data), selectImage: .constant(UIImage()), isBookmarkClick: .constant(false), isPhotoCommentClick: .constant(false), isRecordingCommentClick: .constant(false), isEllipsisClick: .constant(false), info: data, index: 0)
   }
 }

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/Row/AlbumDetailRow.swift
@@ -27,9 +27,17 @@ struct AlbumDetailRow: View {
   
   func saveUIImage() {
     DispatchQueue.global().async {
-      let data = try? Data(contentsOf: URL(string: selectFile!.link)!)
-      DispatchQueue.main.async {
-        self.selectImage = UIImage(data: data!)!
+      do {
+        if let url = URL(string: selectFile!.link) {
+          let data = try Data(contentsOf: url)
+          DispatchQueue.main.async {
+            self.selectImage = UIImage(data: data)!
+          }
+        } else {
+          self.selectImage = UIImage()
+        }
+      } catch {
+        self.selectImage = UIImage()
       }
     }
   }

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListCellViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListCellViewModel.swift
@@ -21,7 +21,7 @@ class AlbumDetailListCellViewModel: ObservableObject {
   }
     
   // 즐겨찾기
-  func fetchAlbumDetailByDate(viewModel: AlbumDetailListViewModel) {
+  func fetchAlbumDetailByDate() {
     AF.request(AlbumDetailManger.postFavourite(fieldId: self.fileId))
       .publishDecodable(type: AlbumFavouriteAPIResponse.self)
       .value()
@@ -43,7 +43,6 @@ class AlbumDetailListCellViewModel: ObservableObject {
         receiveValue: {[weak self] receivedValue in
 //                    print("받은 값 : \(receivedValue)")
           self?.isFavourite = receivedValue.result
-          viewModel.refreshActionSubjectByKind.send()
         }
       )
       .store(in: &subscription)   // disposed(by: disposeBag)

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListCellViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListCellViewModel.swift
@@ -21,7 +21,7 @@ class AlbumDetailListCellViewModel: ObservableObject {
   }
     
   // 즐겨찾기
-  func fetchAlbumDetailByDate() {
+  func fetchAlbumDetailByDate(viewModel: AlbumDetailListViewModel) {
     AF.request(AlbumDetailManger.postFavourite(fieldId: self.fileId))
       .publishDecodable(type: AlbumFavouriteAPIResponse.self)
       .value()
@@ -43,6 +43,7 @@ class AlbumDetailListCellViewModel: ObservableObject {
         receiveValue: {[weak self] receivedValue in
 //                    print("받은 값 : \(receivedValue)")
           self?.isFavourite = receivedValue.result
+          viewModel.refreshActionSubjectByKind.send()
         }
       )
       .store(in: &subscription)   // disposed(by: disposeBag)

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 
 class AlbumDetailListViewModel: ObservableObject {
   @Published var albumDetailList = [AlbumDetailElement]()
+  @Published var type: String = ""
   @Published var isLoading: Bool = false // Loding
   @Published var pageInfo : Info? {
     didSet {
@@ -127,6 +128,7 @@ class AlbumDetailListViewModel: ObservableObject {
         receiveValue: {[weak self] receivedValue in
           //          print("받은 값 : \(receivedValue)")
           self?.albumDetailList = receivedValue.results.elements
+          self?.type = receivedValue.results.type!
           self?.pageInfo = receivedValue.info
           self?.currentPage = 0
         }

--- a/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumDetailView/SubViews/ViewModel/AlbumDetailListViewModel.swift
@@ -103,12 +103,15 @@ class AlbumDetailListViewModel: ObservableObject {
   
   // 유형별
   fileprivate func fetchAlbumDetailByKind() {
+    self.isLoading = true
+    
     AF.request(AlbumDetailManger.getAlbumDetailListByKind(kind: kindType))
       .publishDecodable(type: AlbumDetailAPIResponse.self)
       .value()
       .receive(on: DispatchQueue.main)
       .sink(
         receiveCompletion: {[weak self] in
+          self?.isLoading = false
           guard case .failure(let error) = $0 else { return }
           switch error.responseCode {
           case 400: // 요청 에러 발생했을 때

--- a/Sofa/Sources/View/Album/AlbumRecordAddView/SubViews/ViewModel/AudioRecorderViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumRecordAddView/SubViews/ViewModel/AudioRecorderViewModel.swift
@@ -219,12 +219,17 @@ extension AudioRecorderViewModel: AVAudioPlayerDelegate {
 
 //MARK: - 다운로드
 extension AudioRecorderViewModel {
-  func download(link: String, _ completion: @escaping(Bool) -> Void) {
+  func download(fileName: String?, link: String, _ completion: @escaping(Bool) -> Void) {
     let url = URL(string: link)!
     let fileManager = FileManager.default // 파일매니저
     let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0] // 앱 경로
-    let fileName = url.lastPathComponent.removingPercentEncoding! // 파일이름 url 의 맨 뒤 컴포넌트로 지정 (fileName.m4a) + 한글 인코딩
-    let fileURL = documentsURL.appendingPathComponent(fileName) // 파일 경로 생성
+    var fileURL: URL
+    if let fileName = fileName {
+      fileURL = documentsURL.appendingPathComponent(fileName) // 파일 경로 생성
+    } else {
+      let fileName = url.lastPathComponent.removingPercentEncoding! // 파일이름 url 의 맨 뒤 컴포넌트로 지정 (fileName.m4a) + 한글 인코딩
+      fileURL = documentsURL.appendingPathComponent(fileName) // 파일 경로 생성
+    }
     let destination: DownloadRequest.Destination = { _, _ in // 파일 경로 지정 및 다운로드 옵션 설정 ( 이전 파일 삭제 , 디렉토리 생성 )
       return (fileURL, [.removePreviousFile, .createIntermediateDirectories])
     }

--- a/Sofa/Sources/View/Album/AlbumRecordAddView/SubViews/ViewModel/AudioRecorderViewModel.swift
+++ b/Sofa/Sources/View/Album/AlbumRecordAddView/SubViews/ViewModel/AudioRecorderViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AVFoundation
+import Alamofire
 
 class AudioRecorderViewModel: NSObject, ObservableObject {
   @Published public var soundSamples: [Bool]
@@ -212,6 +213,30 @@ extension AudioRecorderViewModel: AVAudioPlayerDelegate {
     if flag {
       stopInit()
       isPlaying = false
+    }
+  }
+}
+
+//MARK: - 다운로드
+extension AudioRecorderViewModel {
+  func download(link: String, _ completion: @escaping(Bool) -> Void) {
+    let url = URL(string: link)!
+    let fileManager = FileManager.default // 파일매니저
+    let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0] // 앱 경로
+    let fileName = url.lastPathComponent.removingPercentEncoding! // 파일이름 url 의 맨 뒤 컴포넌트로 지정 (fileName.m4a) + 한글 인코딩
+    let fileURL = documentsURL.appendingPathComponent(fileName) // 파일 경로 생성
+    let destination: DownloadRequest.Destination = { _, _ in // 파일 경로 지정 및 다운로드 옵션 설정 ( 이전 파일 삭제 , 디렉토리 생성 )
+      return (fileURL, [.removePreviousFile, .createIntermediateDirectories])
+    }
+    
+    AF.download(url, method: .get, parameters: nil, encoding: JSONEncoding.default, to: destination).downloadProgress { (progress) in
+//      print("progress: \(Int(progress.fractionCompleted * 100))")
+    }.response { response in
+      if response.error != nil {
+        completion(false) // 파일 다운로드 실패
+      } else {
+        completion(true) // 파일 다운로드 완료
+      }
     }
   }
 }

--- a/Sofa/Sources/View/Album/AlbumView.swift
+++ b/Sofa/Sources/View/Album/AlbumView.swift
@@ -89,6 +89,7 @@ struct AlbumView: View {
         }
         .edgesIgnoringSafeArea([.bottom])
       }
+      .navigationViewStyle(StackNavigationViewStyle())
       if showingSheet { // action sheet
         Color.black
           .opacity(0.7)

--- a/Sofa/Sources/View/Album/AlbumView.swift
+++ b/Sofa/Sources/View/Album/AlbumView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-
 struct AlbumView: View {
   @StateObject var viewModel = AlbumListViewModel()
   @ObservedObject var tabbarManager = TabBarManager.shared

--- a/Sofa/Sources/View/Album/AlbumView.swift
+++ b/Sofa/Sources/View/Album/AlbumView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 
 struct AlbumView: View {
+  @StateObject var viewModel = AlbumListViewModel()
   @ObservedObject var tabbarManager = TabBarManager.shared
   @ObservedObject var authorizationViewModel = AuthorizationViewModel()
   @State var currentSelectedTab: Tab = .album // 현재 선택된 탭으로 표시할 곳
@@ -49,7 +50,7 @@ struct AlbumView: View {
           .background(Color.init(hex: "#FAF8F0")) // 임시
           .pickerStyle(SegmentedPickerStyle())
           
-          AlbumList(selectType: selected) // select값에 따른 날짜별, 유형별 View
+          AlbumList(viewModel: viewModel, selectType: selected) // select값에 따른 날짜별, 유형별 View
           
           if (!tabbarManager.showTabBar){
             CustomTabView(selection: $currentSelectedTab)
@@ -65,15 +66,18 @@ struct AlbumView: View {
         .fullScreenCover(isPresented: $authorizationViewModel.showAlbum) {
           // 사진 추가 View로 이동
           AlbumPhotoAddView()
+            .onDisappear { viewModel.refreshActionSubject.send() }
         }
         .fullScreenCover(isPresented: $authorizationViewModel.showCamera) {
           // 카메라 imagePicker로 이동
           CameraImagePicker(selectedImage: $cameraImage, isNext: $showCameraSelectDate)
+            .onDisappear { viewModel.refreshActionSubject.send() }
             .ignoresSafeArea()
         }
         .fullScreenCover(isPresented: $authorizationViewModel.showRecord) {
           // 녹음 추가 View로 이동
           AlbumRecordAddView()
+            .onDisappear { viewModel.refreshActionSubject.send() }
         }
         .alert(isPresented: $authorizationViewModel.showErrorAlert) {
           // 카메라 error

--- a/Sofa/Sources/View/Album/SubViews/Authorization/PhotoAlbumAuthorization.swift
+++ b/Sofa/Sources/View/Album/SubViews/Authorization/PhotoAlbumAuthorization.swift
@@ -36,6 +36,27 @@ struct PhotoAlbumAuthorization {
     }
   }
   
+  static func checkAddPermissions(_ completion: @escaping(Bool) -> Void) throws {
+    
+    switch PHPhotoLibrary.authorizationStatus() {
+    case .authorized:
+
+      completion(true)
+    case .denied:
+      throw PhotoAlbumError.denied
+    case .restricted:
+      throw PhotoAlbumError.restricted
+    case .notDetermined:
+      PHPhotoLibrary.requestAuthorization { grade in
+        if grade == .authorized {
+          completion(true)
+        }
+      }
+    default:
+      break
+    }
+  }
+  
   struct PhotoAlbumErrorType {
     let error: PhotoAlbumAuthorization.PhotoAlbumError
     var message: String {

--- a/Sofa/Sources/View/Album/SubViews/Row/AlbumList.swift
+++ b/Sofa/Sources/View/Album/SubViews/Row/AlbumList.swift
@@ -60,6 +60,9 @@ struct AlbumList: View {
       }
     }
     .padding([.leading, .trailing], 16)
+    .onAppear {
+      self.viewModel.refreshActionSubject.send()
+    }
   }
 }
 

--- a/Sofa/Sources/View/Album/SubViews/Row/AlbumList.swift
+++ b/Sofa/Sources/View/Album/SubViews/Row/AlbumList.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Introspect
 
 struct AlbumList: View {
-  @ObservedObject var viewModel = AlbumListViewModel()
+  @ObservedObject var viewModel: AlbumListViewModel
   @StateObject var scrollViewHelper = ScrollViewHelper(threshold: 100)
   @State var title: String = "앨범 상세"
   @State var showAlbumDetail = false
@@ -65,6 +65,6 @@ struct AlbumList: View {
 
 struct AlbumList_Previews: PreviewProvider {
   static var previews: some View {
-    AlbumList(selectType: 0)
+    AlbumList(viewModel: AlbumListViewModel(), selectType: 0)
   }
 }

--- a/Sofa/Sources/View/Album/SubViews/ViewModel/AlbumListViewModel.swift
+++ b/Sofa/Sources/View/Album/SubViews/ViewModel/AlbumListViewModel.swift
@@ -26,17 +26,19 @@ class AlbumListViewModel: ObservableObject {
   init() {
 //    print(#fileID, #function, #line, "")
     fetchAlbumByDate() // 날짜별
-    fetchAlbumByType() // 유형별
+    fetchAlbumByKind() // 유형별
     
     refreshActionSubject.sink{ [weak self] _ in
       guard let self = self else { return }
       self.fetchAlbumByDate()
+      self.fetchAlbumByKind()
     }.store(in: &subscription)
     
     fetchMoreActionSubject.sink{[weak self] _ in
       guard let self = self else { return }
       if !self.isLoading {
         self.fetchMore()
+        self.fetchAlbumByKind()
       }
     }.store(in: &subscription)
   }
@@ -75,7 +77,8 @@ class AlbumListViewModel: ObservableObject {
   }
   
   // 유형별
-  fileprivate func fetchAlbumByType() {
+  fileprivate func fetchAlbumByKind() {
+    self.albumKindList = [AlbumKind]()
     AF.request(AlbumManager.getAlbumListByKind)
       .publishDecodable(type: AlbumTypeAPIResponse.self)
       .value()

--- a/Sofa/Sources/View/Album/SubViews/ViewModel/AuthorizationViewModel.swift
+++ b/Sofa/Sources/View/Album/SubViews/ViewModel/AuthorizationViewModel.swift
@@ -37,6 +37,25 @@ class AuthorizationViewModel: ObservableObject {
     }
   }
   
+  // Photo Alum 추가 전, 권한 확인
+  func showPhotoAlbum(selectImage: UIImage) {
+    do {
+      try PhotoAlbumAuthorization.checkAddPermissions() { [weak self] (true) in
+        self?.showAlbum = true
+        UIImageWriteToSavedPhotosAlbum(selectImage, self, nil, nil) // 이미지 다운로드
+      }
+    } catch { // 권한 오류가 발생
+      showErrorAlert = true
+      showErrorAlertTitle = "앨범 접근 오류"
+      photoAlubmError = PhotoAlbumAuthorization.PhotoAlbumErrorType(error: error as! PhotoAlbumAuthorization.PhotoAlbumError)
+      showErrorAlertMessage = photoAlubmError!.message
+    }
+  }
+  
+  @objc func saveCompleted(_ image: UIImage, didFinishSavingWithError error: Error?, contextInfo: UnsafeRawPointer) {
+      print("Save finished!")
+  }
+  
   // camera picker 보기 전, 권한 확인
   func showCameraPicker() {
     do {


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 즐겨찾기 등록/해제 후, scroll하면 깜빡이는 문제 해결
- 유형별 - 즐겨찾기 - 즐겨찾기를 해제하면 게시물이 사라지는 기능 구현
- 업로드 후, 바로 앨범 List에 추가하기
- 버벅임 및 로직 분리
- 이미지 다운로드 전, 권한 확인 및 설정으로 안내
- Alamofire를 이용한 파일(녹음) 다운로드

🌱 PR 포인트
- Alamofire로 다운로드하는 방법이 있는데 굉장히 쉬워서 나중에 사용하실때 추천드립니다. bbd5f3dffb5550f40a93e16b18f7349165f55da3
- PR은 8시쯤 하겠습니다.

## 📮 관련 이슈
- Resolved: #132 
