### PR TITLE
[FIX] Home Detail 수정

### DIFF
--- a/Sofa/Configuration/Extensions/Ex+String.swift
+++ b/Sofa/Configuration/Extensions/Ex+String.swift
@@ -43,4 +43,14 @@ extension String {
       return nil
     }
   }
+  
+}
+
+func getTodayDate() -> String { // 오늘 날짜 format
+  let nowDate = Date() // 현재의 Date
+
+  let dateFormatter = DateFormatter()
+  dateFormatter.dateFormat = "yyyy-MM-dd"
+  
+  return dateFormatter.string(from: nowDate)
 }

--- a/Sofa/SofaApp.swift
+++ b/Sofa/SofaApp.swift
@@ -31,17 +31,19 @@ struct SofaApp: App {
   var body: some Scene {
     WindowGroup {
       
-      if KeychainWrapper.standard.string(forKey: "accessToken") != nil{ // Access Token 있다면, 홈 화면
-        ContentView()
-      }
-      else{ // 로그인 필요
-        LoginView()
-          .onOpenURL { url in
-            if (AuthApi.isKakaoTalkLoginUrl(url)){
-              _ = AuthController.handleOpenUrl(url: url)
-            }
-          }
-      }
+//      if KeychainWrapper.standard.string(forKey: "accessToken") != nil{ // Access Token 있다면, 홈 화면
+//        ContentView()
+//      }
+//      else{ // 로그인 필요
+//        LoginView()
+//          .onOpenURL { url in
+//            if (AuthApi.isKakaoTalkLoginUrl(url)){
+//              _ = AuthController.handleOpenUrl(url: url)
+//            }
+//          }
+//      }
+      
+      ContentView()
       
     }
   }

--- a/Sofa/Sources/View/ContentView.swift
+++ b/Sofa/Sources/View/ContentView.swift
@@ -24,6 +24,7 @@ enum Tab{
 
 struct ContentView: View {
   @State private var selection: Tab = .home
+  @State var dateToShow: String = getTodayDate()
   @ObservedObject var tabbarManager = TabBarManager.shared
   
 
@@ -32,15 +33,15 @@ struct ContentView: View {
       ZStack{
         switch selection {
         case .home:
-          HomeView(selectionType: $selection)
+          HomeView(selectionType: $selection, dateToShow: $dateToShow)
         case .calendar:
-          CalendarView()
+          CalendarView(currentDate: dateToShow.toDateDay()!)
         case .album:
           AlbumView()
         case .setting:
           SettingsView()
         default:
-          HomeView(selectionType: $selection)
+          HomeView(selectionType: $selection, dateToShow: $dateToShow)
         }
       }
             

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -14,6 +14,7 @@ struct HomeView: View {
   @State var showModal = false
   @State var showMessageView = false
   @Binding var selectionType: Tab
+  @Binding var dateToShow: String
   @State var text: String?
   @State var placeholder = "가족에게 인사를 남겨보세요."
   @State var currentSelectedTab: Tab = .home // 현재 선택된 탭으로 표시할 곳
@@ -47,7 +48,7 @@ struct HomeView: View {
           .frame(height: 44)
           ScrollView{
             VStack{
-              EventList(eventViewModel: eventViewModel, page: .first(), alignment: .start, selectionType: $selectionType)
+              EventList(eventViewModel: eventViewModel, page: .first(), alignment: .start, selectionType: $selectionType, dateToShow: $dateToShow)
                 .frame(height: eventViewModel.events.count == 0 ? 0 : 64)
                 .padding(.vertical, eventViewModel.events.count == 0 ? 0 : 16)
                 .animation(.default)

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -53,8 +53,8 @@ struct HomeView: View {
                 .padding(.vertical, eventViewModel.events.count == 0 ? 0 : 16)
                 .animation(.default)
             }
-            .overlay(Rectangle().frame(width: nil, height: 1, alignment: .top).foregroundColor(Color(hex: "EDEADF")), alignment: .top)
-            .overlay(Rectangle().frame(width: nil, height: 1, alignment: .bottom).foregroundColor(Color(hex: "EDEADF")), alignment: .bottom)
+            .overlay(Rectangle().frame(width: nil, height: eventViewModel.events.count == 0 ? 0 : 1, alignment: .top).foregroundColor(Color(hex: "EDEADF")), alignment: .top)
+            .overlay(Rectangle().frame(width: nil, height: eventViewModel.events.count == 0 ? 0 : 1, alignment: .bottom).foregroundColor(Color(hex: "EDEADF")), alignment: .bottom)
             .background(Color(hex: "F5F2E9"))
             ChatList(showModal: $showModal)
               .fullScreenCover(isPresented: $showModal) {

--- a/Sofa/Sources/View/Home/HomeView.swift
+++ b/Sofa/Sources/View/Home/HomeView.swift
@@ -70,6 +70,7 @@ struct HomeView: View {
           }// ScrollView
           .background(Color(hex: "F9F7EF"))
           EmojiView(messageShow: $showMessageView)
+            .frame(height: showMessageView ? 0 : 52, alignment: .center)
             .offset(x: 0, y: -24)
             .padding(.horizontal, 23)
             .edgesIgnoringSafeArea(.all)

--- a/Sofa/Sources/View/Home/MessageView.swift
+++ b/Sofa/Sources/View/Home/MessageView.swift
@@ -29,6 +29,7 @@ struct MessageView: View {
   @State var fullTextEditorHeight: CGFloat = 0 // TextEditor가 Full일 때 높이
   @State var isKeyboard: Bool = false // 현재 키보드 올라와있는지
   @State var firstResponder: FirstResponders? = Sofa.FirstResponders.text
+  @State var showTF = false
   let callback: (() -> ())?
 
   init(_ isShowing: Binding<Bool>, _ text: Binding<String?>, _ placeholder: Binding<String>, callback: (() -> ())? = nil){
@@ -50,8 +51,16 @@ struct MessageView: View {
         .onTapGesture {
           self.isShowing = false
         }
-        mainView
-          .offset(y: -self.keyboardHeightHelper.keyboardHeight)
+        .onAppear{
+          DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.00000000000000001) {
+            // 1초 후 실행될 부분
+            showTF = true
+          }
+        }
+        if showTF{
+          mainView
+            .offset(y: -self.keyboardHeightHelper.keyboardHeight)
+        }
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)

--- a/Sofa/Sources/View/Home/SubViews/EmojiView.swift
+++ b/Sofa/Sources/View/Home/SubViews/EmojiView.swift
@@ -22,7 +22,7 @@ struct EmojiView: View {
   var body: some View {
     HStack{
       Capsule()
-        .frame(height: 52, alignment: .center)
+//        .frame(height: 52, alignment: .center)
         .shadow(color: Color.black.opacity(0.16), radius: 4, x: 2, y: 3)
         .foregroundColor(Color.white)
         .overlay(

--- a/Sofa/Sources/View/Home/SubViews/EventList.swift
+++ b/Sofa/Sources/View/Home/SubViews/EventList.swift
@@ -15,6 +15,7 @@ struct EventList: View {
   @State var alignment: SofaPositionAlignment = .start
   @State var viewAppear: Bool = false
   @Binding var selectionType: Tab
+  @Binding var dateToShow: String
   var function: (() -> Void)?
   
   var body: some View {
@@ -33,6 +34,7 @@ struct EventList: View {
           }
           .onTapGesture {
             self.selectionType = .calendar
+            self.dateToShow = eventViewModel.events[index].descriptionDate
           }
       }
     })


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 홈의 일정 클릭 시 해당 날짜 표시하여 캘린더 탭으로 이동
- 일정 Divider
- MessageView 대응

🌱 PR 포인트
- navigationbar도 일괄적으로 수정하려고 하였으나 탭과 연동되면서(?) 로직이 이상해져서 남은 시간동안 수정하도록 하겠습니다.
- ~~messageView는 건형님이 말씀해주신대로 우선 수정해보았는데 제가 볼 땐 대응이 잘 안된 것 같아서 원인을 더 찾아보겠습니다~~
-> 해결했습니다. 1ace517 

## 📸 스크린샷
|EventRow to CalendarTab|EventRow to CalendarTab|
|:--:|:--:|
|![Simulator Screen Recording - iPhone 13 - 2022-07-30 at 13 50 16](https://user-images.githubusercontent.com/70887135/181873666-5111bfb8-c722-4984-ae5c-96c844ce2eb9.gif)|![Simulator Screen Recording - iPhone 13 - 2022-07-30 at 13 51 39](https://user-images.githubusercontent.com/70887135/181874361-7f7925ce-7c18-4a02-9e68-b0632f0cb364.gif)|


## 📮 관련 이슈
- Resolved: #142
