### PR TITLE
[FEAT] 회원가입의 가족 생성과 유저 정보 수정 API 연결

### DIFF
--- a/Sofa.xcodeproj/project.pbxproj
+++ b/Sofa.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		6F22E53C284B9D5A0069D268 /* Base.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F22E53B284B9D5A0069D268 /* Base.swift */; };
 		6F22E53E284B9D640069D268 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F22E53D284B9D640069D268 /* Constants.swift */; };
 		6F347EC828951AED005329DE /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F347EC728951AED005329DE /* SettingViewModel.swift */; };
+		6F347ECE28955E44005329DE /* UserPatchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F347ECD28955E44005329DE /* UserPatchResponse.swift */; };
 		6F3E3EBC286B1E3900EF7082 /* AppendTaskModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3E3EBB286B1E3900EF7082 /* AppendTaskModalView.swift */; };
 		6F6E5A572882B7FF00C0734E /* ProfileSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6E5A562882B7FF00C0734E /* ProfileSettingView.swift */; };
 		6F7340BA2874184300707AB7 /* GeneralCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7340B92874184300707AB7 /* GeneralCalendar.swift */; };
@@ -85,7 +86,7 @@
 		6F809424288AE0B100CD12F8 /* TaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F809423288AE0B100CD12F8 /* TaskViewModel.swift */; };
 		6F809427288AE17700CD12F8 /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F809426288AE17700CD12F8 /* RegisterViewModel.swift */; };
 		6F809429288AE18500CD12F8 /* RegisterFamilyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F809428288AE18500CD12F8 /* RegisterFamilyViewModel.swift */; };
-		6F80942B288AE29100CD12F8 /* RegisterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F80942A288AE29100CD12F8 /* RegisterManager.swift */; };
+		6F80942B288AE29100CD12F8 /* UserFamilyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F80942A288AE29100CD12F8 /* UserFamilyManager.swift */; };
 		6F80942F288B1CA600CD12F8 /* RegisterUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F80942E288B1CA600CD12F8 /* RegisterUser.swift */; };
 		6F809455288D258A00CD12F8 /* RegisterResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F809454288D258A00CD12F8 /* RegisterResponse.swift */; };
 		6F809457288D3E4100CD12F8 /* FamilySettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F809456288D3E4000CD12F8 /* FamilySettingView.swift */; };
@@ -274,6 +275,7 @@
 		6F22E53B284B9D5A0069D268 /* Base.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base.swift; sourceTree = "<group>"; };
 		6F22E53D284B9D640069D268 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		6F347EC728951AED005329DE /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		6F347ECD28955E44005329DE /* UserPatchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPatchResponse.swift; sourceTree = "<group>"; };
 		6F3E3EBB286B1E3900EF7082 /* AppendTaskModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendTaskModalView.swift; sourceTree = "<group>"; };
 		6F6E5A542882B26A00C0734E /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		6F6E5A562882B7FF00C0734E /* ProfileSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingView.swift; sourceTree = "<group>"; };
@@ -283,7 +285,7 @@
 		6F809423288AE0B100CD12F8 /* TaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModel.swift; sourceTree = "<group>"; };
 		6F809426288AE17700CD12F8 /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		6F809428288AE18500CD12F8 /* RegisterFamilyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFamilyViewModel.swift; sourceTree = "<group>"; };
-		6F80942A288AE29100CD12F8 /* RegisterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterManager.swift; sourceTree = "<group>"; };
+		6F80942A288AE29100CD12F8 /* UserFamilyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFamilyManager.swift; sourceTree = "<group>"; };
 		6F80942E288B1CA600CD12F8 /* RegisterUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterUser.swift; sourceTree = "<group>"; };
 		6F809454288D258A00CD12F8 /* RegisterResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterResponse.swift; sourceTree = "<group>"; };
 		6F809456288D3E4000CD12F8 /* FamilySettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FamilySettingView.swift; sourceTree = "<group>"; };
@@ -572,6 +574,7 @@
 				0A2887F52870A80B000A72F2 /* FamilyList.swift */,
 				0AF2B5412884601B00C6A55E /* LoginResponse.swift */,
 				6F809454288D258A00CD12F8 /* RegisterResponse.swift */,
+				6F347ECD28955E44005329DE /* UserPatchResponse.swift */,
 				6F80942E288B1CA600CD12F8 /* RegisterUser.swift */,
 				0A915DD6287A9BA00055AD6D /* Notifications.swift */,
 				0AE492052876A9B000341D35 /* HistoryInfo.swift */,
@@ -589,7 +592,7 @@
 				C4AC88632889B29D00BA5921 /* AlbumDetailManger.swift */,
 				C4AC886E288EE3D300BA5921 /* CommentManger.swift */,
 				0AF2B5432884613D00C6A55E /* LoginManager.swift */,
-				6F80942A288AE29100CD12F8 /* RegisterManager.swift */,
+				6F80942A288AE29100CD12F8 /* UserFamilyManager.swift */,
 				C4AC88562886A15000BA5921 /* UploadManager.swift */,
 			);
 			path = Network;
@@ -1485,7 +1488,7 @@
 				C495F5F12855C3AA009B3BDE /* AlbumKindRow.swift in Sources */,
 				6F809455288D258A00CD12F8 /* RegisterResponse.swift in Sources */,
 				6FE6D78928619A1D00E3C21E /* CustomDatePicker.swift in Sources */,
-				6F80942B288AE29100CD12F8 /* RegisterManager.swift in Sources */,
+				6F80942B288AE29100CD12F8 /* UserFamilyManager.swift in Sources */,
 				0A915DD5287A9B8C0055AD6D /* NotificationViewModel.swift in Sources */,
 				C4B4963528800DDF000C9E1F /* AlbumListViewModel.swift in Sources */,
 				6F809427288AE17700CD12F8 /* RegisterViewModel.swift in Sources */,
@@ -1532,6 +1535,7 @@
 				6F3E3EBC286B1E3900EF7082 /* AppendTaskModalView.swift in Sources */,
 				0ABA0C1D2857A30E005F2C6A /* LoginButtonView.swift in Sources */,
 				0A2B55092858779D006F816C /* View.swift in Sources */,
+				6F347ECE28955E44005329DE /* UserPatchResponse.swift in Sources */,
 				C4EC31E128504F2B0049F2C4 /* AlbumList.swift in Sources */,
 				0AF2B54028845FF900C6A55E /* LoginViewModel.swift in Sources */,
 				C4B8F2C12852912D0000B8CB /* AlbumPhotoAddList.swift in Sources */,

--- a/Sofa/Sources/Models/RegisterUser.swift
+++ b/Sofa/Sources/Models/RegisterUser.swift
@@ -19,6 +19,10 @@ struct RegisterFamily: Decodable {
   let familyMotto: String
 }
 
+struct FamilyID: Decodable {
+  let familyId: Int
+}
+
 struct SimpleUser: Decodable {
   let userId: Int?
   let nickname: String?

--- a/Sofa/Sources/Models/RegisterUser.swift
+++ b/Sofa/Sources/Models/RegisterUser.swift
@@ -12,19 +12,11 @@ struct RegisterUser: Decodable {
   let roleInFamily: String
   let birthDay: String
   let nickname: String
-  
-  static func getDummy() -> Self{
-    return RegisterUser(name: "홍길동", roleInFamily: "아들", birthDay: "1960-02-02", nickname: "홍길동")
-  }
 }
 
 struct RegisterFamily: Decodable {
   let familyName: String
   let familyMotto: String
-  
-  static func getDummy() -> Self{
-    return RegisterFamily(familyName: "우리가족 짱짱", familyMotto: "착하게 살자")
-  }
 }
 
 struct SimpleUser: Decodable {

--- a/Sofa/Sources/Models/UserPatchResponse.swift
+++ b/Sofa/Sources/Models/UserPatchResponse.swift
@@ -1,0 +1,8 @@
+//
+//  UserPatchResponse.swift
+//  Sofa
+//
+//  Created by 임주민 on 2022/07/30.
+//
+
+import Foundation

--- a/Sofa/Sources/Models/UserPatchResponse.swift
+++ b/Sofa/Sources/Models/UserPatchResponse.swift
@@ -6,3 +6,11 @@
 //
 
 import Foundation
+
+struct UserPatchResponse: Decodable {
+  let timestamp: String?
+  let status: Int?
+  let error: String?
+  let path: String?
+  let detail: String?
+}

--- a/Sofa/Sources/Network/RegisterManager.swift
+++ b/Sofa/Sources/Network/RegisterManager.swift
@@ -54,7 +54,6 @@ enum RegisterManager: URLRequestConvertible {
     case .registerFamily:
       headers["Content-Type"] = "application/json"
       headers["accept"] = "application/json"
-      headers["Authenticate"] = "access Token"
     case .getUserSimple:
       return headers
     case .getUserDetail:
@@ -72,7 +71,6 @@ enum RegisterManager: URLRequestConvertible {
       params["roleInFamily"] = roleInFamily
       params["birthDay"] = birthDay
       params["nickname"] = nickname
-      
     case let .registerFamily(familyName: familyName, familyMotto: familyMotto):
       params["familyName"] = familyName
       params["familyMotto"] = familyMotto
@@ -101,7 +99,6 @@ enum RegisterManager: URLRequestConvertible {
     case .getUserDetail:
       request = try URLEncoding.default.encode(request, with: nil)
     }
-    
     return request
   }
 }

--- a/Sofa/Sources/Network/UserFamilyManager.swift
+++ b/Sofa/Sources/Network/UserFamilyManager.swift
@@ -15,6 +15,7 @@ enum UserFamilyManager: URLRequestConvertible {
   case registerFamily(familyName: String, familyMotto: String)
   case getUserSimple
   case getUserDetail
+  case patchUser(imageLink: String, birthDay: String, roleInFamily: String, nickname: String)
   
   var baseURL: URL {
     switch self {
@@ -26,6 +27,8 @@ enum UserFamilyManager: URLRequestConvertible {
       return URL(string: "\(APIConstants.url)/user/simple")!
     case .getUserDetail:
       return URL(string: "\(APIConstants.url)/user/detail")!
+    case .patchUser:
+      return URL(string: "\(APIConstants.url)/user")!
     }
   }
   
@@ -39,6 +42,8 @@ enum UserFamilyManager: URLRequestConvertible {
       return .get
     case .getUserDetail:
       return .get
+    case .patchUser:
+      return .patch
     }
   }
   
@@ -58,6 +63,9 @@ enum UserFamilyManager: URLRequestConvertible {
       return headers
     case .getUserDetail:
       return headers
+    case .patchUser:
+      headers["Content-Type"] = "application/json"
+      headers["accept"] = "application/json"
     }
     return headers
   }
@@ -78,6 +86,11 @@ enum UserFamilyManager: URLRequestConvertible {
       break
     case .getUserDetail:
       break
+    case let .patchUser(imageLink: imageLink, birthDay: birthDay, roleInFamily: roleInFamily, nickname: nickname):
+      params["imageLink"] = imageLink
+      params["birthDay"] = birthDay
+      params["roleInFamily"] = roleInFamily
+      params["nickname"] = nickname
     }
     return params
   }
@@ -98,6 +111,8 @@ enum UserFamilyManager: URLRequestConvertible {
       request = try URLEncoding.default.encode(request, with: nil)
     case .getUserDetail:
       request = try URLEncoding.default.encode(request, with: nil)
+    case .patchUser:
+      request.httpBody = try JSONEncoding.default.encode(request, with: parameters).httpBody
     }
     return request
   }

--- a/Sofa/Sources/Network/UserFamilyManager.swift
+++ b/Sofa/Sources/Network/UserFamilyManager.swift
@@ -1,5 +1,5 @@
 //
-//  RegisterManager.swift
+//  UserFamilyManager.swift
 //  Sofa
 //
 //  Created by 임주민 on 2022/07/22.
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 import Combine
 
-enum RegisterManager: URLRequestConvertible {
+enum UserFamilyManager: URLRequestConvertible {
   
   case registerUser(name: String, roleInFamily: String, birthDay: String, nickname: String)
   case registerFamily(familyName: String, familyMotto: String)

--- a/Sofa/Sources/View/Settings/SubViews/ProfileSettingView.swift
+++ b/Sofa/Sources/View/Settings/SubViews/ProfileSettingView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProfileSettingView: View {
   
   @Environment(\.presentationMode) var presentable
+  @ObservedObject var settingViewModel = SettingViewModel()
   @ObservedObject var tabbarManager = TabBarManager.shared
   
   @State var isChangeProfile: Bool = false
@@ -124,6 +125,7 @@ struct ProfileSettingView: View {
           .accentColor(Color(hex: "#43A047"))
           .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)),
           trailing: Button(action: {
+            settingViewModel.patchUser(imageLink: "https://..", birthDay: birthDay, roleInFamily: roleName, nickname: nickName)
             presentable.wrappedValue.dismiss()
             tabbarManager.showTabBar = true
             UITabBar.showTabBar()
@@ -203,7 +205,6 @@ struct ProfileSettingView: View {
   }///actionSheetView
   
 }///struct
-
 
 struct profileText: View { //별명, 성함 등..
   var text: String

--- a/Sofa/Sources/View/Settings/ViewModel/SettingViewModel.swift
+++ b/Sofa/Sources/View/Settings/ViewModel/SettingViewModel.swift
@@ -13,12 +13,12 @@ class SettingViewModel: ObservableObject {
   
   var subscription = Set<AnyCancellable>()
   
-  @Published var registerResponse: RegisterResponse
+  @Published var userPatchResponse: UserPatchResponse
   @Published var simpleUser: SimpleUser
   @Published var detailUser: DetailUser
   
   init() {
-    registerResponse = RegisterResponse(timestamp: "", status: 0, error: "", path: "", detail: "")
+    userPatchResponse = UserPatchResponse(timestamp: "", status: 0, error: "", path: "", detail: "")
     simpleUser = SimpleUser(userId: 0, nickname: "", name: "", roleInfamily: "", imageLink: "")
     detailUser = DetailUser(nickname: "", name: "", roleInFamily: "", birth: "", imageLink: "")
     print(#fileID, #function, #line, "")
@@ -29,7 +29,7 @@ class SettingViewModel: ObservableObject {
   
   func getUserSimple() { // '설정'뷰의 유저 정보 불러오기
     print(#fileID, #function, #line, "")
-    AF.request(RegisterManager.getUserSimple)
+    AF.request(UserFamilyManager.getUserSimple)
       .publishDecodable(type: SimpleUser.self)
       .value()
       .sink(
@@ -43,7 +43,7 @@ class SettingViewModel: ObservableObject {
   
   func getUserDetail() {  // '프로필 설정'뷰의 유저 정보 불러오기
     print(#fileID, #function, #line, "")
-    AF.request(RegisterManager.getUserDetail)
+    AF.request(UserFamilyManager.getUserDetail)
       .publishDecodable(type: DetailUser.self)
       .value()
       .sink(
@@ -51,6 +51,20 @@ class SettingViewModel: ObservableObject {
         },
         receiveValue: { receivedValue in
           self.detailUser = receivedValue
+        })
+      .store(in: &subscription)
+  }
+  
+  func patchUser(imageLink: String, birthDay: String, roleInFamily: String, nickname: String) {  // 유저 정보 수정
+    print(#fileID, #function, #line, "")
+    AF.request(UserFamilyManager.patchUser(imageLink: imageLink, birthDay: birthDay, roleInFamily: roleInFamily, nickname: nickname))
+      .publishDecodable(type: UserPatchResponse.self)
+      .value()
+      .sink(
+        receiveCompletion: { completion in
+        },
+        receiveValue: { receivedValue in
+          self.userPatchResponse = receivedValue
         })
       .store(in: &subscription)
   }

--- a/Sofa/Sources/View/Welcome/RegisterFamilyView.swift
+++ b/Sofa/Sources/View/Welcome/RegisterFamilyView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct RegisterFamilyView: View {
   
+  @ObservedObject var registerFamilyViewModel = RegisterFamilyViewModel()
+  
   @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
   
   @State var showFinishModal: Bool = false
@@ -131,6 +133,7 @@ struct RegisterFamilyView: View {
           if currentSteps == 1 {
             currentSteps += 1
           } else {
+            registerFamilyViewModel.registerFamily(familyName: familyInfo[0], familyMotto: familyInfo[1])
             showFinishModal.toggle()
           }
         }

--- a/Sofa/Sources/View/Welcome/RegisterView.swift
+++ b/Sofa/Sources/View/Welcome/RegisterView.swift
@@ -7,68 +7,6 @@
 
 import SwiftUI
 
-struct UITextFieldRepresentable: UIViewRepresentable {
-    @Binding var text: String
-    var isFirstResponder: Bool = false
-    var isNumberPad: Bool = false
-    @Binding var isFocused: Bool
-    
-  func makeUIView(context: UIViewRepresentableContext<UITextFieldRepresentable>) -> UITextField {
-    let textField = UITextField(frame: .zero)
-    textField.delegate = context.coordinator
-    textField.textColor = UIColor.clear
-    textField.autocorrectionType = .no
-    if isNumberPad { textField.keyboardType = .numberPad
-    }
-    
-    return textField
-  }
-  
-    func updateUIView(_ uiView: UITextField, context: UIViewRepresentableContext<UITextFieldRepresentable>) {
-        uiView.text = self.text
-        if isFirstResponder && !context.coordinator.didFirstResponder {
-            uiView.becomeFirstResponder()
-            context.coordinator.didFirstResponder = true
-        }
-      if isNumberPad { uiView.keyboardType = .numberPad
-      }
-    }
-    
-    func makeCoordinator() -> UITextFieldRepresentable.Coordinator {
-      Coordinator(text: self.$text, isFocused: self.$isFocused)
-    }
-    
-    class Coordinator: NSObject, UITextFieldDelegate {
-        @Binding var text: String
-        @Binding var isFocused: Bool
-        var didFirstResponder = false
-        var isNumberPad = false
-        
-      init(text: Binding<String>, isFocused: Binding<Bool>) {
-            self._text = text
-            self._isFocused = isFocused
-        }
-        
-        func textFieldDidChangeSelection(_ textField: UITextField) {
-            self.text = textField.text ?? ""
-        }
-        
-        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            textField.resignFirstResponder()
-          
-          return true
-        }
-        
-        func textFieldDidBeginEditing(_ textField: UITextField) {
-            self.isFocused = true
-        }
-        
-        func textFieldDidEndEditing(_ textField: UITextField) {
-            self.isFocused = false
-        }
-    }
-}
-
 struct RegisterView: View {
   
   @ObservedObject var registerViewModel: RegisterViewModel
@@ -316,6 +254,68 @@ struct RegisterView: View {
       }
     }
   }
+}
+
+struct UITextFieldRepresentable: UIViewRepresentable {
+    @Binding var text: String
+    var isFirstResponder: Bool = false
+    var isNumberPad: Bool = false
+    @Binding var isFocused: Bool
+    
+  func makeUIView(context: UIViewRepresentableContext<UITextFieldRepresentable>) -> UITextField {
+    let textField = UITextField(frame: .zero)
+    textField.delegate = context.coordinator
+    textField.textColor = UIColor.clear
+    textField.autocorrectionType = .no
+    if isNumberPad { textField.keyboardType = .numberPad
+    }
+    
+    return textField
+  }
+  
+    func updateUIView(_ uiView: UITextField, context: UIViewRepresentableContext<UITextFieldRepresentable>) {
+        uiView.text = self.text
+        if isFirstResponder && !context.coordinator.didFirstResponder {
+            uiView.becomeFirstResponder()
+            context.coordinator.didFirstResponder = true
+        }
+      if isNumberPad { uiView.keyboardType = .numberPad
+      }
+    }
+    
+    func makeCoordinator() -> UITextFieldRepresentable.Coordinator {
+      Coordinator(text: self.$text, isFocused: self.$isFocused)
+    }
+    
+    class Coordinator: NSObject, UITextFieldDelegate {
+        @Binding var text: String
+        @Binding var isFocused: Bool
+        var didFirstResponder = false
+        var isNumberPad = false
+        
+      init(text: Binding<String>, isFocused: Binding<Bool>) {
+            self._text = text
+            self._isFocused = isFocused
+        }
+        
+        func textFieldDidChangeSelection(_ textField: UITextField) {
+            self.text = textField.text ?? ""
+        }
+        
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            textField.resignFirstResponder()
+          
+          return true
+        }
+        
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            self.isFocused = true
+        }
+        
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            self.isFocused = false
+        }
+    }
 }
 
 //struct RegisterView_Previews: PreviewProvider {

--- a/Sofa/Sources/View/Welcome/ViewModel/RegisterFamilyViewModel.swift
+++ b/Sofa/Sources/View/Welcome/ViewModel/RegisterFamilyViewModel.swift
@@ -6,3 +6,34 @@
 //
 
 import Foundation
+import Combine
+import Alamofire
+
+class RegisterFamilyViewModel: ObservableObject {
+  
+  var subscription = Set<AnyCancellable>()
+
+  @Published var familyID: FamilyID
+  
+  init() {
+    familyID = FamilyID(familyId: 0)
+    print(#fileID, #function, #line, "")
+  }
+  
+  // 가족 등록 post -> familyID 받는 함수
+  func registerFamily(familyName: String, familyMotto: String) {
+    AF.request(RegisterManager.registerFamily(familyName: familyName, familyMotto: familyMotto))
+      .publishDecodable(type: FamilyID.self)
+      .value()
+      .receive(on: DispatchQueue.main)
+      .map { $0 }
+      .sink(
+        receiveCompletion: { completion in
+        },
+        receiveValue: { receivedValue in
+          self.familyID = receivedValue
+          //print(receivedValue.familyId)
+        })
+      .store(in: &subscription)
+  }
+}

--- a/Sofa/Sources/View/Welcome/ViewModel/RegisterFamilyViewModel.swift
+++ b/Sofa/Sources/View/Welcome/ViewModel/RegisterFamilyViewModel.swift
@@ -22,7 +22,7 @@ class RegisterFamilyViewModel: ObservableObject {
   
   // 가족 등록 post -> familyID 받는 함수
   func registerFamily(familyName: String, familyMotto: String) {
-    AF.request(RegisterManager.registerFamily(familyName: familyName, familyMotto: familyMotto))
+    AF.request(UserFamilyManager.registerFamily(familyName: familyName, familyMotto: familyMotto))
       .publishDecodable(type: FamilyID.self)
       .value()
       .receive(on: DispatchQueue.main)

--- a/Sofa/Sources/View/Welcome/ViewModel/RegisterViewModel.swift
+++ b/Sofa/Sources/View/Welcome/ViewModel/RegisterViewModel.swift
@@ -22,7 +22,7 @@ class RegisterViewModel: ObservableObject {
   
   func register(name: String, roleInFamily: String, birthDay: String, nickname: String) {
     print("UserVM: register() called")
-    AF.request(RegisterManager.registerUser(name: name, roleInFamily: roleInFamily, birthDay: birthDay, nickname: nickname))
+    AF.request(UserFamilyManager.registerUser(name: name, roleInFamily: roleInFamily, birthDay: birthDay, nickname: nickname))
       .publishDecodable(type: RegisterResponse.self)
       .value()
       .receive(on: DispatchQueue.main)


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 가족 이름과 가훈으로 가족을 등록하고, familyID를 받는 POST방식의 API를 연결하였습니다.
- 가족 이름과 가훈을 보내고 서버로부터 familyID 받는 것까지 확인 했습니다.
- 설정에서 유저 정보 수정하는 PATCH방식의 API를 연결하였습니다.

🌱 PR 포인트
- 작업한 파일 중, RegisterView.swift의 파일은 코드 위치를 이동한 것 뿐이여서 보시지 않으셔도 됩니다!

## 📮 관련 이슈
- Resolved: #147 
